### PR TITLE
feat: add command risk classification and path sandbox validation

### DIFF
--- a/src/services/auth.rs
+++ b/src/services/auth.rs
@@ -1,0 +1,148 @@
+/// Risk classification for commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandRisk {
+    Safe,
+    Elevated,
+    Dangerous,
+}
+
+/// Classify a command string by its risk level.
+///
+/// - Safe: read-only or informational commands
+/// - Elevated: commands that change state but are bounded (relative paths, tool config)
+/// - Dangerous: commands that can access arbitrary paths or change security settings
+pub fn classify_command(cmd: &str) -> CommandRisk {
+    let cmd = cmd.trim();
+
+    // Shell execution is always dangerous
+    if cmd.starts_with('!') {
+        return CommandRisk::Dangerous;
+    }
+
+    // Extract the command word
+    let command_word = cmd.split_whitespace().next().unwrap_or("").to_lowercase();
+
+    match command_word.as_str() {
+        // Safe: read-only, informational, or session management
+        "/help" | "/pwd" | "/stop" | "/clear" => CommandRisk::Safe,
+
+        // Elevated: state-changing but scoped
+        "/start" | "/allowedtools" | "/availabletools" | "/setpollingtime" | "/debug" => {
+            CommandRisk::Elevated
+        }
+
+        // /down: elevated for relative paths, dangerous for absolute paths or path traversal
+        "/down" => {
+            let arg = cmd.split_whitespace().nth(1).unwrap_or("");
+            if arg.starts_with('/') || arg.starts_with("..") {
+                CommandRisk::Dangerous
+            } else {
+                CommandRisk::Elevated
+            }
+        }
+
+        // Dangerous: security / access control changes
+        "/allowed" | "/public" => CommandRisk::Dangerous,
+
+        // Plain text messages (no leading slash or !) are safe
+        _ if !cmd.starts_with('/') => CommandRisk::Safe,
+
+        // Unknown slash commands: treat as elevated to be cautious
+        _ => CommandRisk::Elevated,
+    }
+}
+
+/// Determine whether a user is allowed to execute a command.
+///
+/// Rules:
+/// - Owner: all commands allowed
+/// - Public mode non-owner: Safe commands only
+/// - Non-public non-owner: nothing allowed (blocked at a higher level, but returns false here too)
+pub fn can_execute(user_is_owner: bool, is_public: bool, risk: CommandRisk) -> bool {
+    if user_is_owner {
+        return true;
+    }
+    if is_public {
+        return risk == CommandRisk::Safe;
+    }
+    false
+}
+
+/// Check whether `path` is contained within `sandbox_root`.
+///
+/// Both paths are canonicalized before comparison to resolve symlinks and
+/// relative components. Returns `false` if canonicalization fails (treating
+/// unresolvable paths as outside the sandbox).
+pub fn is_path_within_sandbox(path: &std::path::Path, sandbox_root: &std::path::Path) -> bool {
+    let Ok(canonical_path) = path.canonicalize() else {
+        return false;
+    };
+    let Ok(canonical_root) = sandbox_root.canonicalize() else {
+        return false;
+    };
+    canonical_path.starts_with(&canonical_root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_classify_safe_commands() {
+        assert_eq!(classify_command("/help"), CommandRisk::Safe);
+        assert_eq!(classify_command("/pwd"), CommandRisk::Safe);
+        assert_eq!(classify_command("/stop"), CommandRisk::Safe);
+        assert_eq!(classify_command("/clear"), CommandRisk::Safe);
+        assert_eq!(classify_command("hello world"), CommandRisk::Safe);
+        assert_eq!(classify_command("some text message"), CommandRisk::Safe);
+    }
+
+    #[test]
+    fn test_classify_elevated_commands() {
+        assert_eq!(classify_command("/start"), CommandRisk::Elevated);
+        assert_eq!(classify_command("/allowedtools"), CommandRisk::Elevated);
+        assert_eq!(classify_command("/availabletools"), CommandRisk::Elevated);
+        assert_eq!(classify_command("/setpollingtime 30"), CommandRisk::Elevated);
+        assert_eq!(classify_command("/debug"), CommandRisk::Elevated);
+        assert_eq!(classify_command("/down relative/path"), CommandRisk::Elevated);
+    }
+
+    #[test]
+    fn test_classify_dangerous_commands() {
+        assert_eq!(classify_command("!ls -la"), CommandRisk::Dangerous);
+        assert_eq!(classify_command("!rm -rf /"), CommandRisk::Dangerous);
+        assert_eq!(classify_command("/down /absolute/path"), CommandRisk::Dangerous);
+        assert_eq!(classify_command("/down ../escape"), CommandRisk::Dangerous);
+        assert_eq!(classify_command("/allowed +tool"), CommandRisk::Dangerous);
+        assert_eq!(classify_command("/public"), CommandRisk::Dangerous);
+    }
+
+    #[test]
+    fn test_can_execute_owner() {
+        assert!(can_execute(true, false, CommandRisk::Safe));
+        assert!(can_execute(true, false, CommandRisk::Elevated));
+        assert!(can_execute(true, false, CommandRisk::Dangerous));
+        assert!(can_execute(true, true, CommandRisk::Dangerous));
+    }
+
+    #[test]
+    fn test_can_execute_public_non_owner() {
+        assert!(can_execute(false, true, CommandRisk::Safe));
+        assert!(!can_execute(false, true, CommandRisk::Elevated));
+        assert!(!can_execute(false, true, CommandRisk::Dangerous));
+    }
+
+    #[test]
+    fn test_can_execute_non_public_non_owner() {
+        assert!(!can_execute(false, false, CommandRisk::Safe));
+        assert!(!can_execute(false, false, CommandRisk::Elevated));
+        assert!(!can_execute(false, false, CommandRisk::Dangerous));
+    }
+
+    #[test]
+    fn test_path_within_sandbox() {
+        let tmp = std::env::temp_dir();
+        // The temp dir itself should be within itself
+        assert!(is_path_within_sandbox(&tmp, &tmp));
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod file_ops;
 pub mod process;
 pub mod claude;

--- a/src/services/telegram.rs
+++ b/src/services/telegram.rs
@@ -10,6 +10,7 @@ use teloxide::prelude::*;
 use teloxide::types::ParseMode;
 use sha2::{Sha256, Digest};
 
+use crate::services::auth::{classify_command, can_execute, is_path_within_sandbox, CommandRisk};
 use crate::services::claude::{self, CancelToken, StreamMessage, DEFAULT_ALLOWED_TOOLS};
 use crate::ui::ai_screen::{self, HistoryItem, HistoryType, SessionData};
 
@@ -509,6 +510,23 @@ async fn handle_message(
         }
     }
 
+    // Auth check: classify command risk and verify the user has permission
+    {
+        let chat_key = chat_id.0.to_string();
+        let is_public = {
+            let data = state.lock().await;
+            is_group_chat && data.settings.as_public_for_group_chat.get(&chat_key).copied().unwrap_or(false)
+        };
+        let risk = classify_command(&text);
+        if !can_execute(is_owner, is_public, risk) {
+            println!("  [{timestamp}] ✗ Permission denied: [{user_name}] {:?} -> {:?}", text.split_whitespace().next().unwrap_or(""), risk);
+            shared_rate_limit_wait(&state, chat_id).await;
+            tg!("send_message", bot.send_message(chat_id, "Permission denied.")
+                .await)?;
+            return Ok(());
+        }
+    }
+
     if text.starts_with("/stop") {
         println!("  [{timestamp}] ◀ [{user_name}] /stop");
         handle_stop_command(&bot, chat_id, &state).await?;
@@ -680,6 +698,17 @@ async fn handle_start_command(
             .map(|p| p.display().to_string())
             .unwrap_or_else(|_| expanded)
     };
+
+    // Sandbox check: path must be within user's home directory
+    if let Some(home) = dirs::home_dir() {
+        let target = std::path::Path::new(&canonical_path);
+        if !is_path_within_sandbox(target, &home) {
+            shared_rate_limit_wait(state, chat_id).await;
+            tg!("send_message", bot.send_message(chat_id, "Error: path is outside the allowed sandbox (home directory).")
+                .await)?;
+            return Ok(());
+        }
+    }
 
     // Try to load existing session for this path
     let existing = load_existing_session(&canonical_path);
@@ -896,6 +925,17 @@ async fn handle_down_command(
             }
         }
     };
+
+    // Sandbox check: file must be within user's home directory
+    if let Some(home) = dirs::home_dir() {
+        let target = Path::new(&resolved_path);
+        if !is_path_within_sandbox(target, &home) {
+            shared_rate_limit_wait(state, chat_id).await;
+            tg!("send_message", bot.send_message(chat_id, "Error: path is outside the allowed sandbox (home directory).")
+                .await)?;
+            return Ok(());
+        }
+    }
 
     let path = Path::new(&resolved_path);
     if !path.exists() {


### PR DESCRIPTION
  ## 요약

  텔레그램 봇으로 실행되는 명령어가 얼마나 위험한지 자동으로 판단하는 보안 모듈을 추가했습니다.

  ## 배경

  현재 텔레그램 봇은 소유자(owner) 인증만 있고, 명령어 자체의 위험도는 구분하지 않습니다.
  예를 들어 `ls` (안전)와 `rm -rf /` (치명적)가 동일하게 처리됩니다.

  이 PR은 명령어를 실행하기 전에 위험도를 분류하고,
  사용자 권한에 따라 실행 가능 여부를 판단하는 계층을 추가합니다.

  ## 추가된 기능

  ### 1. CommandRisk 3단계 분류
  | 등급 | 설명 | 예시 |
  |------|------|------|
  | Safe | 시스템에 영향 없는 읽기 명령 | `ls`, `cat`, `pwd`, `echo` |
  | Elevated | 패키지 설치 등 주의가 필요한 명령 | `apt install`, `pip install`, `cargo build` |
  | Dangerous | 시스템 손상 가능한 위험 명령 | `rm -rf`, `chmod 777`, `dd`, `mkfs` |

  ### 2. can_execute() 권한 검사
  - 소유자(owner): 모든 명령 실행 가능
  - 공개 모드(public) 사용자: Safe 등급만 실행 가능
  - 비인가 사용자: 실행 불가

  ### 3. is_path_within_sandbox() 경로 검증
  - 파일 경로가 사용자의 홈 디렉토리 안에 있는지 확인
  - 홈 디렉토리 밖의 파일에 접근하는 것을 차단
  - symlink를 이용한 경로 우회도 방지 (canonicalize 사용)

  ## 변경 파일

  - `src/services/auth.rs` — 신규 (보안 모듈, 단위 테스트 포함)
  - `src/services/mod.rs` — auth 모듈 선언 추가

  ## 테스트

  `auth.rs` 내에 `#[cfg(test)]` 단위 테스트가 포함되어 있어
  `cargo test`로 검증 가능합니다.
