### PR TITLE
feat: add i18n multilingual support (Korean/English)

### DIFF
--- a/src/services/i18n/en.rs
+++ b/src/services/i18n/en.rs
@@ -1,0 +1,114 @@
+// English localization strings.
+
+// Session
+pub(super) const MSG_NO_SESSION: &str =
+    "No active session. Use /start <path> first.";
+pub(super) const MSG_SESSION_CLEARED: &str = "Session cleared.";
+
+// AI busy
+pub(super) const MSG_AI_BUSY: &str =
+    "AI request in progress. Use /stop to cancel.";
+
+// Permission
+pub(super) const MSG_PERMISSION_DENIED: &str = "Permission denied.";
+
+// Stop
+pub(super) const MSG_STOPPING: &str = "Stopping...";
+pub(super) const MSG_NO_ACTIVE_REQUEST: &str = "No active request to stop.";
+
+// Public
+pub(super) const MSG_GROUP_ONLY: &str =
+    "This command is only available in group chats.";
+pub(super) const MSG_PUBLIC_OWNER_ONLY: &str =
+    "Only the bot owner can change public access settings.";
+pub(super) const MSG_PUBLIC_ON: &str =
+    "✅ Public access <b>enabled</b> for this group.\nAll members can now use the bot.";
+pub(super) const MSG_PUBLIC_OFF: &str =
+    "❌ Public access <b>disabled</b> for this group.\nOnly the owner can use the bot.";
+pub(super) const MSG_PUBLIC_STATUS_ENABLED: &str = "enabled";
+pub(super) const MSG_PUBLIC_STATUS_DISABLED: &str = "disabled";
+pub(super) const MSG_PUBLIC_STATUS: &str =
+    "Public access is currently <b>{}</b> for this group.\n\n<code>/public on</code> — Allow all members\n<code>/public off</code> — Owner only";
+pub(super) const MSG_PUBLIC_USAGE: &str =
+    "Usage:\n<code>/public on</code> — Allow all group members\n<code>/public off</code> — Owner only";
+
+// Language
+pub(super) const MSG_LANG_CHANGED: &str = "✅ Language set to <b>English</b>.";
+pub(super) const MSG_LANG_USAGE: &str =
+    "Usage: <code>/lang ko</code> or <code>/lang en</code>";
+
+// Shell
+pub(super) const MSG_SHELL_USAGE: &str =
+    "Usage: !<command>\nExample: !mkdir /home/user/testcode";
+pub(super) const MSG_SHELL_TIMEOUT: &str = "Command execution timed out (60s limit)";
+pub(super) const MSG_SHELL_PROCESSING: &str = "Processing !{}...";
+
+// Down (file download)
+pub(super) const MSG_DOWN_USAGE: &str =
+    "Usage: /down <filepath>\nExample: /down /home/user/file.txt";
+pub(super) const MSG_DOWN_NO_SESSION: &str =
+    "No active session. Use absolute path or /start <path> first.";
+
+// File ops
+pub(super) const MSG_FILE_SAVE_FAILED: &str = "Failed to save file: {}";
+pub(super) const MSG_SANDBOX_DENIED: &str =
+    "Error: path is outside the allowed sandbox (home directory).";
+
+// Errors
+pub(super) const MSG_ERROR_HOME: &str =
+    "Error: cannot determine home directory.";
+pub(super) const MSG_ERROR_INVALID_DIR: &str =
+    "Error: '{}' is not a valid directory.";
+pub(super) const MSG_ERROR_CREATE_WORKSPACE: &str =
+    "Error: failed to create workspace: {}";
+
+// Help text
+pub(super) fn help_text() -> &'static str {
+    "\
+<b>cokacdir Telegram Bot</b>
+Manage server files &amp; chat with Claude AI.
+
+<b>Session</b>
+<code>/start &lt;path&gt;</code> — Start session at directory
+<code>/start</code> — Start with auto-generated workspace
+<code>/pwd</code> — Show current working directory
+<code>/clear</code> — Clear AI conversation history
+<code>/stop</code> — Stop current AI request
+
+<b>File Transfer</b>
+<code>/down &lt;file&gt;</code> — Download file from server
+Send a file/photo — Upload to session directory
+
+<b>Shell</b>
+<code>!&lt;command&gt;</code> — Run shell command directly
+  e.g. <code>!ls -la</code>, <code>!git status</code>
+
+<b>AI Chat</b>
+Any other message is sent to Claude AI.
+AI can read, edit, and run commands in your session.
+
+<b>Tool Management</b>
+<code>/availabletools</code> — List all available tools
+<code>/allowedtools</code> — Show currently allowed tools
+<code>/allowed +name</code> — Add tool (e.g. <code>/allowed +Bash</code>)
+<code>/allowed -name</code> — Remove tool
+<code>/allowed +a -b +c</code> — Multiple at once
+
+<b>Group Chat</b>
+<code>;</code><i>message</i> — Send message to AI
+<code>;</code><i>caption</i> — Upload file with AI prompt
+<code>/public on</code> — Allow all members to use bot
+<code>/public off</code> — Owner only (default)
+
+<b>Language</b>
+<code>/lang ko</code> — 한국어
+<code>/lang en</code> — English
+
+<b>Settings</b>
+<code>/setpollingtime &lt;ms&gt;</code> — Set API polling interval
+  Too low may cause Telegram API rate limits.
+  Minimum 2500ms, recommended 3000ms+.
+<code>/debug</code> — Toggle API debug logging
+
+<code>/help</code> — Show this help"
+}

--- a/src/services/i18n/ko.rs
+++ b/src/services/i18n/ko.rs
@@ -1,0 +1,108 @@
+// Korean localization strings.
+
+// Session
+pub(super) const MSG_NO_SESSION: &str =
+    "활성 세션이 없습니다. /start <경로> 로 시작하세요.";
+pub(super) const MSG_SESSION_CLEARED: &str = "세션이 초기화되었습니다.";
+
+// AI busy
+pub(super) const MSG_AI_BUSY: &str = "AI 요청이 진행 중입니다. /stop 으로 중단할 수 있습니다.";
+
+// Permission
+pub(super) const MSG_PERMISSION_DENIED: &str = "권한 없음.";
+
+// Stop
+pub(super) const MSG_STOPPING: &str = "중단 중...";
+pub(super) const MSG_NO_ACTIVE_REQUEST: &str = "중단할 활성 요청이 없습니다.";
+
+// Public
+pub(super) const MSG_GROUP_ONLY: &str = "이 명령은 그룹 채팅에서만 사용할 수 있습니다.";
+pub(super) const MSG_PUBLIC_OWNER_ONLY: &str =
+    "봇 소유자만 public 접근 설정을 변경할 수 있습니다.";
+pub(super) const MSG_PUBLIC_ON: &str =
+    "✅ 이 그룹의 Public 접근이 <b>활성화</b>되었습니다.\n모든 멤버가 봇을 사용할 수 있습니다.";
+pub(super) const MSG_PUBLIC_OFF: &str =
+    "❌ 이 그룹의 Public 접근이 <b>비활성화</b>되었습니다.\n소유자만 봇을 사용할 수 있습니다.";
+pub(super) const MSG_PUBLIC_STATUS_ENABLED: &str = "활성화됨";
+pub(super) const MSG_PUBLIC_STATUS_DISABLED: &str = "비활성화됨";
+pub(super) const MSG_PUBLIC_STATUS: &str =
+    "이 그룹의 Public 접근 상태: <b>{}</b>\n\n<code>/public on</code> — 모든 멤버 허용\n<code>/public off</code> — 소유자만";
+pub(super) const MSG_PUBLIC_USAGE: &str =
+    "사용법:\n<code>/public on</code> — 모든 그룹 멤버 허용\n<code>/public off</code> — 소유자만";
+
+// Language
+pub(super) const MSG_LANG_CHANGED: &str = "✅ 언어가 <b>한국어</b>로 설정되었습니다.";
+pub(super) const MSG_LANG_USAGE: &str =
+    "사용법: <code>/lang ko</code> 또는 <code>/lang en</code>";
+
+// Shell
+pub(super) const MSG_SHELL_USAGE: &str = "사용법: !<명령어>\n예시: !mkdir /home/user/testcode";
+pub(super) const MSG_SHELL_TIMEOUT: &str = "명령 실행 시간 초과 (60초 제한)";
+pub(super) const MSG_SHELL_PROCESSING: &str = "{}에 대해서 처리중입니다.";
+
+// Down (file download)
+pub(super) const MSG_DOWN_USAGE: &str =
+    "사용법: /down <파일경로>\n예시: /down /home/user/file.txt";
+pub(super) const MSG_DOWN_NO_SESSION: &str =
+    "활성 세션이 없습니다. 절대 경로를 사용하거나 먼저 /start <경로>로 시작하세요.";
+
+// File ops
+pub(super) const MSG_FILE_SAVE_FAILED: &str = "파일 저장 실패: {}";
+pub(super) const MSG_SANDBOX_DENIED: &str =
+    "오류: 경로가 허용된 샌드박스(홈 디렉토리) 밖에 있습니다.";
+
+// Errors
+pub(super) const MSG_ERROR_HOME: &str = "오류: 홈 디렉토리를 확인할 수 없습니다.";
+pub(super) const MSG_ERROR_INVALID_DIR: &str = "오류: '{}' 은(는) 유효한 디렉토리가 아닙니다.";
+pub(super) const MSG_ERROR_CREATE_WORKSPACE: &str = "오류: 워크스페이스 생성 실패: {}";
+
+// Help text
+pub(super) fn help_text() -> &'static str {
+    "\
+<b>cokacdir Telegram Bot</b>
+서버 파일 관리 &amp; Claude AI 대화
+
+<b>세션</b>
+<code>/start &lt;경로&gt;</code> — 디렉토리에서 세션 시작
+<code>/start</code> — 자동 생성 워크스페이스로 시작
+<code>/pwd</code> — 현재 작업 경로 확인
+<code>/clear</code> — AI 대화 기록 삭제
+<code>/stop</code> — 현재 AI 요청 중단
+
+<b>파일 전송</b>
+<code>/down &lt;파일&gt;</code> — 서버 파일 다운로드
+파일/사진 전송 — 세션 디렉토리에 업로드
+
+<b>셸 명령어</b>
+<code>!&lt;명령어&gt;</code> — 셸 명령어 직접 실행
+  예: <code>!ls -la</code>, <code>!git status</code>
+
+<b>AI 대화</b>
+다른 메시지는 Claude AI 에게 전송됩니다.
+AI는 세션의 파일을 읽고, 수정하고, 명령을 실행할 수 있습니다.
+
+<b>도구 관리</b>
+<code>/availabletools</code> — 전체 도구 목록
+<code>/allowedtools</code> — 현재 허용된 도구 목록
+<code>/allowed +이름</code> — 도구 추가 (예: <code>/allowed +Bash</code>)
+<code>/allowed -이름</code> — 도구 제거
+<code>/allowed +a -b +c</code> — 여러 개 동시에
+
+<b>그룹 채팅</b>
+<code>;</code><i>메시지</i> — AI에게 메시지 전송
+<code>;</code><i>캡션</i> — AI 프롬프트와 함께 파일 업로드
+<code>/public on</code> — 모든 멤버 사용 허용
+<code>/public off</code> — 소유자만 (기본값)
+
+<b>언어</b>
+<code>/lang ko</code> — 한국어
+<code>/lang en</code> — English
+
+<b>설정</b>
+<code>/setpollingtime &lt;ms&gt;</code> — API 폴링 간격 설정
+  너무 낮으면 Telegram API 속도 제한이 발생할 수 있습니다.
+  최소 2500ms, 권장 3000ms 이상.
+<code>/debug</code> — API 디버그 로깅 토글
+
+<code>/help</code> — 이 도움말 표시"
+}

--- a/src/services/i18n/mod.rs
+++ b/src/services/i18n/mod.rs
@@ -1,0 +1,226 @@
+mod en;
+mod ko;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Lang {
+    Ko,
+    En,
+}
+
+impl Default for Lang {
+    fn default() -> Self {
+        Lang::Ko
+    }
+}
+
+pub fn resolve_lang(code: &str) -> Lang {
+    match code.to_lowercase().as_str() {
+        "en" => Lang::En,
+        _ => Lang::Ko,
+    }
+}
+
+// Session
+pub fn msg_no_session(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_NO_SESSION,
+        Lang::En => en::MSG_NO_SESSION,
+    }
+}
+
+pub fn msg_session_cleared(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_SESSION_CLEARED,
+        Lang::En => en::MSG_SESSION_CLEARED,
+    }
+}
+
+// AI busy
+pub fn msg_ai_busy(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_AI_BUSY,
+        Lang::En => en::MSG_AI_BUSY,
+    }
+}
+
+// Permission
+pub fn msg_permission_denied(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_PERMISSION_DENIED,
+        Lang::En => en::MSG_PERMISSION_DENIED,
+    }
+}
+
+// Stop
+pub fn msg_stopping(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_STOPPING,
+        Lang::En => en::MSG_STOPPING,
+    }
+}
+
+pub fn msg_no_active_request(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_NO_ACTIVE_REQUEST,
+        Lang::En => en::MSG_NO_ACTIVE_REQUEST,
+    }
+}
+
+// Public
+pub fn msg_group_only(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_GROUP_ONLY,
+        Lang::En => en::MSG_GROUP_ONLY,
+    }
+}
+
+pub fn msg_public_owner_only(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_PUBLIC_OWNER_ONLY,
+        Lang::En => en::MSG_PUBLIC_OWNER_ONLY,
+    }
+}
+
+pub fn msg_public_enabled(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_PUBLIC_ON,
+        Lang::En => en::MSG_PUBLIC_ON,
+    }
+}
+
+pub fn msg_public_disabled(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_PUBLIC_OFF,
+        Lang::En => en::MSG_PUBLIC_OFF,
+    }
+}
+
+pub fn msg_public_status(lang: Lang, status: &str) -> String {
+    let tpl = match lang {
+        Lang::Ko => ko::MSG_PUBLIC_STATUS,
+        Lang::En => en::MSG_PUBLIC_STATUS,
+    };
+    tpl.replacen("{}", status, 1)
+}
+
+pub fn msg_public_status_label(lang: Lang, is_public: bool) -> &'static str {
+    if is_public {
+        match lang {
+            Lang::Ko => ko::MSG_PUBLIC_STATUS_ENABLED,
+            Lang::En => en::MSG_PUBLIC_STATUS_ENABLED,
+        }
+    } else {
+        match lang {
+            Lang::Ko => ko::MSG_PUBLIC_STATUS_DISABLED,
+            Lang::En => en::MSG_PUBLIC_STATUS_DISABLED,
+        }
+    }
+}
+
+pub fn msg_public_usage(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_PUBLIC_USAGE,
+        Lang::En => en::MSG_PUBLIC_USAGE,
+    }
+}
+
+// Language
+pub fn msg_lang_changed(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_LANG_CHANGED,
+        Lang::En => en::MSG_LANG_CHANGED,
+    }
+}
+
+pub fn msg_lang_usage(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_LANG_USAGE,
+        Lang::En => en::MSG_LANG_USAGE,
+    }
+}
+
+// Shell
+pub fn msg_shell_usage(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_SHELL_USAGE,
+        Lang::En => en::MSG_SHELL_USAGE,
+    }
+}
+
+pub fn msg_shell_timeout(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_SHELL_TIMEOUT,
+        Lang::En => en::MSG_SHELL_TIMEOUT,
+    }
+}
+
+pub fn msg_shell_processing(lang: Lang, cmd: &str) -> String {
+    let tpl = match lang {
+        Lang::Ko => ko::MSG_SHELL_PROCESSING,
+        Lang::En => en::MSG_SHELL_PROCESSING,
+    };
+    tpl.replacen("{}", cmd, 1)
+}
+
+// Down (file download)
+pub fn msg_down_usage(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_DOWN_USAGE,
+        Lang::En => en::MSG_DOWN_USAGE,
+    }
+}
+
+pub fn msg_down_no_session(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_DOWN_NO_SESSION,
+        Lang::En => en::MSG_DOWN_NO_SESSION,
+    }
+}
+
+// File ops
+pub fn msg_file_save_failed(lang: Lang, err: &str) -> String {
+    let tpl = match lang {
+        Lang::Ko => ko::MSG_FILE_SAVE_FAILED,
+        Lang::En => en::MSG_FILE_SAVE_FAILED,
+    };
+    tpl.replacen("{}", err, 1)
+}
+
+pub fn msg_sandbox_denied(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_SANDBOX_DENIED,
+        Lang::En => en::MSG_SANDBOX_DENIED,
+    }
+}
+
+// Errors
+pub fn msg_error_home(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::MSG_ERROR_HOME,
+        Lang::En => en::MSG_ERROR_HOME,
+    }
+}
+
+pub fn msg_error_invalid_dir(lang: Lang, dir: &str) -> String {
+    let tpl = match lang {
+        Lang::Ko => ko::MSG_ERROR_INVALID_DIR,
+        Lang::En => en::MSG_ERROR_INVALID_DIR,
+    };
+    tpl.replacen("{}", dir, 1)
+}
+
+pub fn msg_error_create_workspace(lang: Lang, err: &str) -> String {
+    let tpl = match lang {
+        Lang::Ko => ko::MSG_ERROR_CREATE_WORKSPACE,
+        Lang::En => en::MSG_ERROR_CREATE_WORKSPACE,
+    };
+    tpl.replacen("{}", err, 1)
+}
+
+// Help
+pub fn help_text(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Ko => ko::help_text(),
+        Lang::En => en::help_text(),
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod file_ops;
+pub mod i18n;
 pub mod process;
 pub mod claude;
 pub mod remote;

--- a/src/services/telegram.rs
+++ b/src/services/telegram.rs
@@ -11,6 +11,7 @@ use teloxide::types::ParseMode;
 use sha2::{Sha256, Digest};
 
 use crate::services::claude::{self, CancelToken, StreamMessage, DEFAULT_ALLOWED_TOOLS};
+use crate::services::i18n::{self, Lang, resolve_lang};
 use crate::ui::ai_screen::{self, HistoryItem, HistoryType, SessionData};
 
 /// Global debug log flag for Telegram API calls
@@ -71,6 +72,8 @@ struct BotSettings {
     owner_user_id: Option<u64>,
     /// chat_id (string) → true if group chat is public (non-owner users allowed)
     as_public_for_group_chat: HashMap<String, bool>,
+    /// chat_id (string) → language code ("ko" or "en")
+    chat_language: HashMap<String, String>,
 }
 
 impl Default for BotSettings {
@@ -80,6 +83,7 @@ impl Default for BotSettings {
             last_sessions: HashMap::new(),
             owner_user_id: None,
             as_public_for_group_chat: HashMap::new(),
+            chat_language: HashMap::new(),
         }
     }
 }
@@ -91,6 +95,14 @@ fn get_allowed_tools(settings: &BotSettings, chat_id: ChatId) -> Vec<String> {
     settings.allowed_tools.get(&key)
         .cloned()
         .unwrap_or_else(|| DEFAULT_ALLOWED_TOOLS.iter().map(|s| s.to_string()).collect())
+}
+
+/// Get language for a specific chat_id. Defaults to Korean.
+fn get_chat_lang(settings: &BotSettings, chat_id: ChatId) -> Lang {
+    let key = chat_id.0.to_string();
+    settings.chat_language.get(&key)
+        .map(|code| resolve_lang(code))
+        .unwrap_or_default()
 }
 
 /// Shared state: per-chat sessions + bot settings
@@ -191,7 +203,16 @@ fn load_bot_settings(token: &str) -> BotSettings {
         })
         .unwrap_or_default();
 
-    BotSettings { allowed_tools, last_sessions, owner_user_id, as_public_for_group_chat }
+    let chat_language: HashMap<String, String> = entry.get("chat_language")
+        .and_then(|v| v.as_object())
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    BotSettings { allowed_tools, last_sessions, owner_user_id, as_public_for_group_chat, chat_language }
 }
 
 /// Save bot settings to bot_settings.json
@@ -213,6 +234,7 @@ fn save_bot_settings(token: &str, settings: &BotSettings) {
         "allowed_tools": settings.allowed_tools,
         "last_sessions": settings.last_sessions,
         "as_public_for_group_chat": settings.as_public_for_group_chat,
+        "chat_language": settings.chat_language,
     });
     if let Some(owner_id) = settings.owner_user_id {
         entry["owner_user_id"] = serde_json::json!(owner_id);
@@ -540,6 +562,9 @@ async fn handle_message(
     } else if text.starts_with("/setpollingtime") {
         println!("  [{timestamp}] ◀ [{user_name}] /setpollingtime {}", text.strip_prefix("/setpollingtime").unwrap_or("").trim());
         handle_setpollingtime_command(&bot, chat_id, &text, &state).await?;
+    } else if text.starts_with("/lang") {
+        println!("  [{timestamp}] ◀ [{user_name}] /lang {}", text.strip_prefix("/lang").unwrap_or("").trim());
+        handle_lang_command(&bot, chat_id, &text, &state, token).await?;
     } else if text.starts_with("/debug") {
         println!("  [{timestamp}] ◀ [{user_name}] /debug");
         handle_debug_command(&bot, chat_id, &state).await?;
@@ -571,49 +596,8 @@ async fn handle_help_command(
     chat_id: ChatId,
     state: &SharedState,
 ) -> ResponseResult<()> {
-    let help = "\
-<b>cokacdir Telegram Bot</b>
-Manage server files &amp; chat with Claude AI.
-
-<b>Session</b>
-<code>/start &lt;path&gt;</code> — Start session at directory
-<code>/start</code> — Start with auto-generated workspace
-<code>/pwd</code> — Show current working directory
-<code>/clear</code> — Clear AI conversation history
-<code>/stop</code> — Stop current AI request
-
-<b>File Transfer</b>
-<code>/down &lt;file&gt;</code> — Download file from server
-Send a file/photo — Upload to session directory
-
-<b>Shell</b>
-<code>!&lt;command&gt;</code> — Run shell command directly
-  e.g. <code>!ls -la</code>, <code>!git status</code>
-
-<b>AI Chat</b>
-Any other message is sent to Claude AI.
-AI can read, edit, and run commands in your session.
-
-<b>Tool Management</b>
-<code>/availabletools</code> — List all available tools
-<code>/allowedtools</code> — Show currently allowed tools
-<code>/allowed +name</code> — Add tool (e.g. <code>/allowed +Bash</code>)
-<code>/allowed -name</code> — Remove tool
-<code>/allowed +a -b +c</code> — Multiple at once
-
-<b>Group Chat</b>
-<code>;</code><i>message</i> — Send message to AI
-<code>;</code><i>caption</i> — Upload file with AI prompt
-<code>/public on</code> — Allow all members to use bot
-<code>/public off</code> — Owner only (default)
-
-<b>Settings</b>
-<code>/setpollingtime &lt;ms&gt;</code> — Set API polling interval
-  Too low may cause Telegram API rate limits.
-  Minimum 2500ms, recommended 3000ms+.
-<code>/debug</code> — Toggle API debug logging
-
-<code>/help</code> — Show this help";
+    let lang = { let d = state.lock().await; get_chat_lang(&d.settings, chat_id) };
+    let help = i18n::help_text(lang);
 
     shared_rate_limit_wait(state, chat_id).await;
     tg!("send_message", bot.send_message(chat_id, help)
@@ -634,11 +618,13 @@ async fn handle_start_command(
     // Extract path from "/start <path>"
     let path_str = text.strip_prefix("/start").unwrap_or("").trim();
 
+    let lang = { let d = state.lock().await; get_chat_lang(&d.settings, chat_id) };
+
     let canonical_path = if path_str.is_empty() {
         // Create random workspace directory
         let Some(home) = dirs::home_dir() else {
             shared_rate_limit_wait(state, chat_id).await;
-            tg!("send_message", bot.send_message(chat_id, "Error: cannot determine home directory.")
+            tg!("send_message", bot.send_message(chat_id, i18n::msg_error_home(lang))
                 .await)?;
             return Ok(());
         };
@@ -652,7 +638,7 @@ async fn handle_start_command(
         let new_dir = workspace_dir.join(&random_name);
         if let Err(e) = fs::create_dir_all(&new_dir) {
             shared_rate_limit_wait(state, chat_id).await;
-            tg!("send_message", bot.send_message(chat_id, format!("Error: failed to create workspace: {}", e))
+            tg!("send_message", bot.send_message(chat_id, i18n::msg_error_create_workspace(lang, &e.to_string()))
                 .await)?;
             return Ok(());
         }
@@ -672,7 +658,7 @@ async fn handle_start_command(
         let path = Path::new(&expanded);
         if !path.exists() || !path.is_dir() {
             shared_rate_limit_wait(state, chat_id).await;
-            tg!("send_message", bot.send_message(chat_id, format!("Error: '{}' is not a valid directory.", expanded))
+            tg!("send_message", bot.send_message(chat_id, i18n::msg_error_invalid_dir(lang, &expanded))
                 .await)?;
             return Ok(());
         }
@@ -780,8 +766,9 @@ async fn handle_clear_command(
         data.stop_message_ids.remove(&chat_id);
     }
 
+    let lang = { let d = state.lock().await; get_chat_lang(&d.settings, chat_id) };
     shared_rate_limit_wait(state, chat_id).await;
-    tg!("send_message", bot.send_message(chat_id, "Session cleared.")
+    tg!("send_message", bot.send_message(chat_id, i18n::msg_session_cleared(lang))
         .await)?;
 
     Ok(())
@@ -798,10 +785,11 @@ async fn handle_pwd_command(
         data.sessions.get(&chat_id).and_then(|s| s.current_path.clone())
     };
 
+    let lang = { let d = state.lock().await; get_chat_lang(&d.settings, chat_id) };
     shared_rate_limit_wait(state, chat_id).await;
     match current_path {
         Some(path) => tg!("send_message", bot.send_message(chat_id, &path).await)?,
-        None => tg!("send_message", bot.send_message(chat_id, "No active session. Use /start <path> first.").await)?,
+        None => tg!("send_message", bot.send_message(chat_id, i18n::msg_no_session(lang)).await)?,
     };
 
     Ok(())
@@ -813,6 +801,7 @@ async fn handle_stop_command(
     chat_id: ChatId,
     state: &SharedState,
 ) -> ResponseResult<()> {
+    let lang = { let d = state.lock().await; get_chat_lang(&d.settings, chat_id) };
     let token = {
         let data = state.lock().await;
         data.cancel_tokens.get(&chat_id).cloned()
@@ -827,7 +816,7 @@ async fn handle_stop_command(
 
             // Send immediate feedback to user
             shared_rate_limit_wait(state, chat_id).await;
-            let stop_msg = tg!("send_message", bot.send_message(chat_id, "Stopping...").await)?;
+            let stop_msg = tg!("send_message", bot.send_message(chat_id, i18n::msg_stopping(lang)).await)?;
 
             // Store the stop message ID so the polling loop can update it later
             {
@@ -854,7 +843,7 @@ async fn handle_stop_command(
         }
         None => {
             shared_rate_limit_wait(state, chat_id).await;
-            tg!("send_message", bot.send_message(chat_id, "No active request to stop.")
+            tg!("send_message", bot.send_message(chat_id, i18n::msg_no_active_request(lang))
                 .await)?;
         }
     }
@@ -869,11 +858,12 @@ async fn handle_down_command(
     text: &str,
     state: &SharedState,
 ) -> ResponseResult<()> {
+    let lang = { let d = state.lock().await; get_chat_lang(&d.settings, chat_id) };
     let file_path = text.strip_prefix("/down").unwrap_or("").trim();
 
     if file_path.is_empty() {
         shared_rate_limit_wait(state, chat_id).await;
-        tg!("send_message", bot.send_message(chat_id, "Usage: /down <filepath>\nExample: /down /home/kst/file.txt")
+        tg!("send_message", bot.send_message(chat_id, i18n::msg_down_usage(lang))
             .await)?;
         return Ok(());
     }
@@ -890,7 +880,7 @@ async fn handle_down_command(
             Some(base) => format!("{}/{}", base.trim_end_matches('/'), file_path),
             None => {
                 shared_rate_limit_wait(state, chat_id).await;
-                tg!("send_message", bot.send_message(chat_id, "No active session. Use absolute path or /start <path> first.")
+                tg!("send_message", bot.send_message(chat_id, i18n::msg_down_no_session(lang))
                     .await)?;
                 return Ok(());
             }
@@ -929,9 +919,10 @@ async fn handle_file_upload(
         data.sessions.get(&chat_id).and_then(|s| s.current_path.clone())
     };
 
+    let lang = { let d = state.lock().await; get_chat_lang(&d.settings, chat_id) };
     let Some(save_dir) = current_path else {
         shared_rate_limit_wait(state, chat_id).await;
-        tg!("send_message", bot.send_message(chat_id, "No active session. Use /start <path> first.")
+        tg!("send_message", bot.send_message(chat_id, i18n::msg_no_session(lang))
             .await)?;
         return Ok(());
     };
@@ -986,7 +977,7 @@ async fn handle_file_upload(
         }
         Err(e) => {
             shared_rate_limit_wait(state, chat_id).await;
-            tg!("send_message", bot.send_message(chat_id, &format!("Failed to save file: {}", e)).await)?;
+            tg!("send_message", bot.send_message(chat_id, &i18n::msg_file_save_failed(lang, &e.to_string())).await)?;
             return Ok(());
         }
     }
@@ -1025,11 +1016,12 @@ async fn handle_shell_command(
     text: &str,
     state: &SharedState,
 ) -> ResponseResult<()> {
+    let lang = { let d = state.lock().await; get_chat_lang(&d.settings, chat_id) };
     let cmd_str = text.strip_prefix('!').unwrap_or("").trim();
 
     if cmd_str.is_empty() {
         shared_rate_limit_wait(state, chat_id).await;
-        tg!("send_message", bot.send_message(chat_id, "Usage: !<command>\nExample: !mkdir /home/kst/testcode")
+        tg!("send_message", bot.send_message(chat_id, i18n::msg_shell_usage(lang))
             .await)?;
         return Ok(());
     }
@@ -1049,7 +1041,7 @@ async fn handle_shell_command(
     // Send placeholder message
     let cmd_display = cmd_str.to_string();
     shared_rate_limit_wait(state, chat_id).await;
-    let placeholder = tg!("send_message", bot.send_message(chat_id, format!("!{}에 대해서 처리중입니다.", &cmd_display)).await)?;
+    let placeholder = tg!("send_message", bot.send_message(chat_id, i18n::msg_shell_processing(lang, &cmd_display)).await)?;
     let placeholder_msg_id = placeholder.id;
 
     // Register cancel token (lock) — must be AFTER placeholder send succeeds,
@@ -1562,16 +1554,18 @@ async fn handle_public_command(
     is_group_chat: bool,
     is_owner: bool,
 ) -> ResponseResult<()> {
+    let lang = { let d = state.lock().await; get_chat_lang(&d.settings, chat_id) };
+
     if !is_group_chat {
         shared_rate_limit_wait(state, chat_id).await;
-        tg!("send_message", bot.send_message(chat_id, "This command is only available in group chats.")
+        tg!("send_message", bot.send_message(chat_id, i18n::msg_group_only(lang))
             .await)?;
         return Ok(());
     }
 
     if !is_owner {
         shared_rate_limit_wait(state, chat_id).await;
-        tg!("send_message", bot.send_message(chat_id, "Only the bot owner can change public access settings.")
+        tg!("send_message", bot.send_message(chat_id, i18n::msg_public_owner_only(lang))
             .await)?;
         return Ok(());
     }
@@ -1584,32 +1578,59 @@ async fn handle_public_command(
             let mut data = state.lock().await;
             data.settings.as_public_for_group_chat.insert(chat_key, true);
             save_bot_settings(token, &data.settings);
-            "✅ Public access <b>enabled</b> for this group.\nAll members can now use the bot.".to_string()
+            i18n::msg_public_enabled(lang).to_string()
         }
         "off" => {
             let mut data = state.lock().await;
             data.settings.as_public_for_group_chat.remove(&chat_key);
             save_bot_settings(token, &data.settings);
-            "❌ Public access <b>disabled</b> for this group.\nOnly the owner can use the bot.".to_string()
+            i18n::msg_public_disabled(lang).to_string()
         }
         "" => {
             let data = state.lock().await;
             let is_public = data.settings.as_public_for_group_chat.get(&chat_key).copied().unwrap_or(false);
-            let status = if is_public { "enabled" } else { "disabled" };
-            format!(
-                "Public access is currently <b>{}</b> for this group.\n\n\
-                 <code>/public on</code> — Allow all members\n\
-                 <code>/public off</code> — Owner only",
-                status
-            )
+            let status = i18n::msg_public_status_label(lang, is_public);
+            i18n::msg_public_status(lang, status)
         }
         _ => {
-            "Usage:\n<code>/public on</code> — Allow all group members\n<code>/public off</code> — Owner only".to_string()
+            i18n::msg_public_usage(lang).to_string()
         }
     };
 
     shared_rate_limit_wait(state, chat_id).await;
     tg!("send_message", bot.send_message(chat_id, &response_msg)
+        .parse_mode(ParseMode::Html)
+        .await)?;
+
+    Ok(())
+}
+
+/// Handle /lang command - change language for this chat
+async fn handle_lang_command(
+    bot: &Bot,
+    chat_id: ChatId,
+    text: &str,
+    state: &SharedState,
+    token: &str,
+) -> ResponseResult<()> {
+    let arg = text.strip_prefix("/lang").unwrap_or("").trim().to_lowercase();
+
+    let (lang, response) = if arg == "ko" || arg == "en" {
+        let new_lang = resolve_lang(&arg);
+        {
+            let mut data = state.lock().await;
+            data.settings.chat_language.insert(chat_id.0.to_string(), arg.clone());
+            save_bot_settings(token, &data.settings);
+        }
+        (new_lang, i18n::msg_lang_changed(new_lang).to_string())
+    } else {
+        let lang = { let d = state.lock().await; get_chat_lang(&d.settings, chat_id) };
+        (lang, i18n::msg_lang_usage(lang).to_string())
+    };
+    let _ = lang; // lang used for response selection above
+
+    shared_rate_limit_wait(state, chat_id).await;
+    tg!("send_message", bot.send_message(chat_id, &response)
         .parse_mode(ParseMode::Html)
         .await)?;
 
@@ -1642,11 +1663,12 @@ async fn handle_text_message(
         (info, tools, uploads)
     };
 
+    let lang = { let d = state.lock().await; get_chat_lang(&d.settings, chat_id) };
     let (session_id, current_path) = match session_info {
         Some(info) => info,
         None => {
             shared_rate_limit_wait(state, chat_id).await;
-            tg!("send_message", bot.send_message(chat_id, "No active session. Use /start <path> first.")
+            tg!("send_message", bot.send_message(chat_id, i18n::msg_no_session(lang))
                 .await)?;
             return Ok(());
         }


### PR DESCRIPTION
  ## 요약

  텔레그램 봇의 모든 메시지를 한국어 또는 영어로 전환할 수 있는 다국어 지원을 추가했습니다.

  ## 배경

  현재 봇이 보내는 모든 메시지(안내, 에러, 도움말 등)가 영어로 고정되어 있습니다.

  한국어 사용자에게는 불편하고,
  앞으로 다른 언어를 추가하려면 구조적인 기반이 필요합니다.

  이 PR은 메시지를 언어별로 분리하고,
  채팅방마다 원하는 언어를 설정할 수 있게 합니다.

  ## 추가된 기능

  ### 1. /lang 명령어
  텔레그램 채팅에서 언어를 바꿀 수 있습니다:

  - `/lang ko` → 봇이 한국어로 응답
  - `/lang en` → 봇이 영어로 응답

  ### 2. 채팅별 언어 설정 저장
  - 각 채팅방마다 언어 설정이 따로 저장됨
  - 봇을 재시작해도 설정이 유지됨
  - BotSettings에 chat_language 필드 추가

  ### 3. i18n 모듈 구조
  src/services/i18n/
  ├── mod.rs   — Lang enum (Ko/En), 언어 선택 로직
  ├── ko.rs    — 한국어 번역 (모든 봇 메시지)
  └── en.rs    — 영어 번역 (모든 봇 메시지)

  새 언어를 추가하려면:
  1. `ja.rs` 같은 파일 추가
  2. `mod.rs`에 Lang enum에 Ja 추가
  3. 각 메시지 함수에 Ja 매칭 추가

  ## 변경 파일

  - `src/services/i18n/mod.rs` — 신규 (언어 선택 로직)
  - `src/services/i18n/ko.rs` — 신규 (한국어 번역)
  - `src/services/i18n/en.rs` — 신규 (영어 번역)
  - `src/services/mod.rs` — i18n 모듈 선언 추가
  - `src/services/telegram.rs` — 기존 하드코딩된 메시지를 i18n 함수로 교체

  ---
  다음!