### PR TITLE
feat: add Backend trait for multi-AI backend abstraction

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,10 @@ fn print_help() {
     println!("    --prompt <TEXT>         Send prompt to AI and print rendered response");
     println!("    --design                Enable theme hot-reload (for theme development)");
     println!("    --base64 <TEXT>         Decode base64 and print (internal use)");
-    println!("    --ccserver <TOKEN>...   Start Telegram bot server(s)");
+    println!("    --ccserver <TOKEN>...   Start Telegram bot server(s) (alias: --openclaude)");
+    println!("    --openclaude <TOKEN>... Start Telegram bot with Claude backend");
+    println!("    --opencodex <TOKEN>...  Start Telegram bot with Codex backend (uses omx if available)");
+    println!("    --madmax                Skip all AI permission checks (use with caution)");
     println!("    --sendfile <PATH> --chat <ID> --key <HASH>");
     println!("                            Send file via Telegram bot (internal use, HASH = token hash)");
     println!("    --ismcptool <TOOL>...    Check if MCP tool(s) are registered in .claude/settings.json (CWD)");
@@ -313,9 +316,19 @@ fn main() -> io::Result<()> {
     let mut design_mode = false;
     let mut start_paths: Vec<std::path::PathBuf> = Vec::new();
 
+    // Pre-scan for --madmax flag (can appear anywhere in args)
+    if args.iter().any(|a| a == "--madmax") {
+        services::backend::set_madmax(true);
+    }
+
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
+            "--madmax" => {
+                // Already handled in pre-scan above
+                i += 1;
+                continue;
+            }
             "-h" | "--help" => {
                 print_help();
                 return Ok(());
@@ -340,14 +353,34 @@ fn main() -> io::Result<()> {
                 handle_base64(&args[i + 1]);
                 return Ok(());
             }
-            "--ccserver" => {
+            "--ccserver" | "--openclaude" => {
                 let tokens: Vec<String> = args[i + 1..].iter()
                     .filter(|a| !a.starts_with('-'))
                     .cloned()
                     .collect();
                 if tokens.is_empty() {
-                    eprintln!("Error: --ccserver requires at least one token argument");
-                    eprintln!("Usage: cokacdir --ccserver <TOKEN> [TOKEN2] ...");
+                    eprintln!("Error: {} requires at least one token argument", args[i]);
+                    eprintln!("Usage: cokacdir {} <TOKEN> [TOKEN2] ...", args[i]);
+                    return Ok(());
+                }
+                handle_ccserver(tokens);
+                return Ok(());
+            }
+            "--opencodex" => {
+                let tokens: Vec<String> = args[i + 1..].iter()
+                    .filter(|a| !a.starts_with('-'))
+                    .cloned()
+                    .collect();
+                if tokens.is_empty() {
+                    eprintln!("Error: --opencodex requires at least one token argument");
+                    eprintln!("Usage: cokacdir --opencodex <TOKEN> [TOKEN2] ...");
+                    return Ok(());
+                }
+                if !services::backend::CodexBackend::is_available() {
+                    eprintln!("Error: Neither omx (Oh My Codex) nor codex CLI found.");
+                    eprintln!("Install one of:");
+                    eprintln!("  npm install -g @openai/codex");
+                    eprintln!("  or install omx (https://github.com/WOULDU-pres/omx)");
                     return Ok(());
                 }
                 handle_ccserver(tokens);

--- a/src/services/backend/claude.rs
+++ b/src/services/backend/claude.rs
@@ -1,0 +1,443 @@
+use std::io::{BufRead, BufReader, Read, Write};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, OnceLock};
+
+use super::{Backend, BackendMessage, CancelToken};
+
+/// Cached path to the claude binary.
+static CLAUDE_BINARY_PATH: OnceLock<Option<String>> = OnceLock::new();
+
+/// Resolve the path to the claude binary.
+/// First tries `which claude`, then falls back to `bash -lc "which claude"`
+/// for non-interactive SSH sessions where ~/.profile isn't loaded.
+fn resolve_claude_binary_path() -> Option<String> {
+    if let Ok(output) = Command::new("which").arg("claude").output() {
+        if output.status.success() {
+            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !path.is_empty() {
+                return Some(path);
+            }
+        }
+    }
+
+    if let Ok(output) = Command::new("bash")
+        .args(["-lc", "which claude"])
+        .output()
+    {
+        if output.status.success() {
+            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !path.is_empty() {
+                return Some(path);
+            }
+        }
+    }
+
+    None
+}
+
+fn get_claude_binary_path() -> Option<&'static str> {
+    CLAUDE_BINARY_PATH
+        .get_or_init(resolve_claude_binary_path)
+        .as_deref()
+}
+
+/// Default allowed tools for Claude CLI
+pub const DEFAULT_ALLOWED_TOOLS: &[&str] = &[
+    "Bash",
+    "Read",
+    "Edit",
+    "Write",
+    "Glob",
+    "Grep",
+    "Task",
+    "TaskOutput",
+    "TaskStop",
+    "WebFetch",
+    "WebSearch",
+    "NotebookEdit",
+    "Skill",
+    "TaskCreate",
+    "TaskGet",
+    "TaskUpdate",
+    "TaskList",
+];
+
+const DEFAULT_SYSTEM_PROMPT: &str = r#"You are a terminal file manager assistant. Be concise. Focus on file operations. Respond in the same language as the user.
+
+SECURITY RULES (MUST FOLLOW):
+- NEVER execute destructive commands like rm -rf, format, mkfs, dd, etc.
+- NEVER modify system files in /etc, /sys, /proc, /boot
+- NEVER access or modify files outside the current working directory without explicit user path
+- NEVER execute commands that could harm the system or compromise security
+- ONLY suggest safe file operations: copy, move, rename, create directory, view, edit
+- If a request seems dangerous, explain the risk and suggest a safer alternative
+
+BASH EXECUTION RULES (MUST FOLLOW):
+- All commands MUST run non-interactively without user input
+- Use -y, --yes, or --non-interactive flags (e.g., apt install -y, npm init -y)
+- Use -m flag for commit messages (e.g., git commit -m "message")
+- Disable pagers with --no-pager or pipe to cat (e.g., git --no-pager log)
+- NEVER use commands that open editors (vim, nano, etc.)
+- NEVER use commands that wait for stdin without arguments
+- NEVER use interactive flags like -i"#;
+
+/// Parse one stream-json JSONL line into a BackendMessage.
+fn parse_line(line: &str) -> Option<BackendMessage> {
+    let json: serde_json::Value = serde_json::from_str(line).ok()?;
+    let event_type = json.get("type").and_then(|v| v.as_str())?;
+
+    match event_type {
+        "system" => {
+            if json.get("subtype").and_then(|v| v.as_str()) == Some("init") {
+                let session_id = json
+                    .get("session_id")
+                    .and_then(|v| v.as_str())?
+                    .to_string();
+                Some(BackendMessage::Init { session_id })
+            } else {
+                None
+            }
+        }
+        "assistant" => {
+            let content = json
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|v| v.as_array())?;
+
+            for block in content {
+                match block.get("type").and_then(|v| v.as_str()) {
+                    Some("text") => {
+                        let text = block
+                            .get("text")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        if !text.is_empty() {
+                            return Some(BackendMessage::Text(text));
+                        }
+                    }
+                    Some("tool_use") => {
+                        let name = block
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("Tool")
+                            .to_string();
+                        let input = block
+                            .get("input")
+                            .map(|v| {
+                                if let Some(s) = v.as_str() {
+                                    s.to_string()
+                                } else {
+                                    serde_json::to_string(v).unwrap_or_default()
+                                }
+                            })
+                            .unwrap_or_default();
+                        return Some(BackendMessage::ToolUse { name, input });
+                    }
+                    _ => {}
+                }
+            }
+            None
+        }
+        "user" => {
+            let content = json
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|v| v.as_array())?;
+
+            for item in content {
+                if item.get("type").and_then(|v| v.as_str()) == Some("tool_result") {
+                    let content_text =
+                        if let Some(s) = item.get("content").and_then(|v| v.as_str()) {
+                            s.to_string()
+                        } else if let Some(arr) = item.get("content").and_then(|v| v.as_array()) {
+                            arr.iter()
+                                .filter_map(|v| v.get("text").and_then(|t| t.as_str()))
+                                .collect::<Vec<_>>()
+                                .join("\n")
+                        } else {
+                            String::new()
+                        };
+                    let is_error = item
+                        .get("is_error")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    return Some(BackendMessage::ToolResult {
+                        content: content_text,
+                        is_error,
+                    });
+                }
+            }
+            None
+        }
+        "result" => {
+            let is_error = json
+                .get("is_error")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            if is_error {
+                let error_msg = json
+                    .get("errors")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str())
+                            .collect::<Vec<_>>()
+                            .join("; ")
+                    })
+                    .or_else(|| {
+                        json.get("result")
+                            .and_then(|v| v.as_str())
+                            .map(String::from)
+                    })
+                    .unwrap_or_else(|| "Unknown error".to_string());
+                return Some(BackendMessage::Error(error_msg));
+            }
+
+            let response = json
+                .get("result")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            Some(BackendMessage::Complete { response })
+        }
+        _ => None,
+    }
+}
+
+/// AI backend that wraps the Claude CLI tool.
+pub struct ClaudeBackend;
+
+impl ClaudeBackend {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ClaudeBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl Backend for ClaudeBackend {
+    async fn execute_streaming(
+        &self,
+        prompt: &str,
+        session_id: Option<&str>,
+        working_dir: &str,
+        sender: tokio::sync::mpsc::Sender<BackendMessage>,
+        system_prompt: Option<&str>,
+        allowed_tools: Option<&[String]>,
+        cancel_token: Option<Arc<CancelToken>>,
+    ) -> Result<(), String> {
+        let claude_bin = get_claude_binary_path()
+            .ok_or_else(|| "Claude CLI not found. Is Claude CLI installed?".to_string())?;
+
+        let tools_str = match allowed_tools {
+            Some(tools) => tools.join(","),
+            None => DEFAULT_ALLOWED_TOOLS.join(","),
+        };
+
+        let mut args = vec![
+            "-p".to_string(),
+        ];
+
+        if super::is_madmax() {
+            args.push("--dangerously-skip-permissions".to_string());
+        } else {
+            args.push("--permission-mode".to_string());
+            args.push("default".to_string());
+        }
+
+        args.extend([
+            "--tools".to_string(),
+            tools_str,
+            "--verbose".to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+        ]);
+
+        let effective_system_prompt = match system_prompt {
+            None => Some(DEFAULT_SYSTEM_PROMPT),
+            Some("") => None,
+            Some(p) => Some(p),
+        };
+        if let Some(sp) = effective_system_prompt {
+            args.push("--append-system-prompt".to_string());
+            args.push(sp.to_string());
+        }
+
+        if let Some(sid) = session_id {
+            args.push("--resume".to_string());
+            args.push(sid.to_string());
+        }
+
+        let prompt_owned = prompt.to_string();
+        let working_dir_owned = working_dir.to_string();
+        let claude_bin_owned = claude_bin.to_string();
+
+        // Run blocking I/O in a dedicated thread
+        let (sync_tx, mut sync_rx) = tokio::sync::mpsc::channel::<BackendMessage>(64);
+        let cancel_token_clone = cancel_token.clone();
+
+        tokio::task::spawn_blocking(move || {
+            let _ = run_claude_process(
+                &claude_bin_owned,
+                &args,
+                &prompt_owned,
+                &working_dir_owned,
+                sync_tx,
+                cancel_token_clone,
+            );
+        });
+
+        // Forward messages from the blocking thread to the caller's sender
+        while let Some(msg) = sync_rx.recv().await {
+            if sender.send(msg).await.is_err() {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "claude"
+    }
+
+    fn binary_path(&self) -> Option<String> {
+        get_claude_binary_path().map(String::from)
+    }
+
+    fn default_allowed_tools(&self) -> Vec<String> {
+        DEFAULT_ALLOWED_TOOLS.iter().map(|s| s.to_string()).collect()
+    }
+}
+
+/// Synchronous worker that drives the claude process and emits BackendMessages.
+fn run_claude_process(
+    claude_bin: &str,
+    args: &[String],
+    prompt: &str,
+    working_dir: &str,
+    sender: tokio::sync::mpsc::Sender<BackendMessage>,
+    cancel_token: Option<Arc<CancelToken>>,
+) -> Result<(), String> {
+    let mut child = Command::new(claude_bin)
+        .args(args)
+        .current_dir(working_dir)
+        .env("CLAUDE_CODE_MAX_OUTPUT_TOKENS", "64000")
+        .env("BASH_DEFAULT_TIMEOUT_MS", "86400000")
+        .env("BASH_MAX_TIMEOUT_MS", "86400000")
+        .env_remove("CLAUDECODE")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to start Claude: {}", e))?;
+
+    if let Some(ref token) = cancel_token {
+        token.set_child_pid(child.id());
+    }
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(prompt.as_bytes());
+    }
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Failed to capture stdout".to_string())?;
+
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Failed to capture stderr".to_string())?;
+
+    let stderr_handle = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let mut reader = BufReader::new(stderr);
+        let _ = reader.read_to_string(&mut buf);
+        buf
+    });
+
+    let mut reader = BufReader::new(stdout);
+    let mut line_buf = String::new();
+    let mut last_session_id: Option<String> = None;
+    let mut done_sent = false;
+
+    loop {
+        if let Some(ref token) = cancel_token {
+            if token.is_cancelled() {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Ok(());
+            }
+        }
+
+        line_buf.clear();
+        let read = reader
+            .read_line(&mut line_buf)
+            .map_err(|e| format!("Failed to read Claude output: {}", e))?;
+
+        if read == 0 {
+            break;
+        }
+
+        let line = line_buf.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if let Some(msg) = parse_line(line) {
+            match &msg {
+                BackendMessage::Init { session_id } => {
+                    last_session_id = Some(session_id.clone());
+                }
+                BackendMessage::Complete { .. } => {
+                    done_sent = true;
+                }
+                _ => {}
+            }
+            if sender.blocking_send(msg).is_err() {
+                break;
+            }
+        }
+    }
+
+    if let Some(ref token) = cancel_token {
+        if token.is_cancelled() {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Ok(());
+        }
+    }
+
+    let status = child
+        .wait()
+        .map_err(|e| format!("Claude process wait failed: {}", e))?;
+
+    let stderr_output = stderr_handle.join().unwrap_or_default();
+
+    if !status.success() {
+        let error_msg = if !stderr_output.trim().is_empty() {
+            stderr_output.trim().to_string()
+        } else {
+            format!("Claude exited with code {:?}", status.code())
+        };
+        let _ = sender.blocking_send(BackendMessage::Error(error_msg));
+    }
+
+    if !done_sent {
+        let response = last_session_id
+            .as_deref()
+            .map(|_| String::new())
+            .unwrap_or_default();
+        let _ = sender.blocking_send(BackendMessage::Complete { response });
+    }
+
+    Ok(())
+}

--- a/src/services/backend/codex.rs
+++ b/src/services/backend/codex.rs
@@ -1,0 +1,418 @@
+use std::io::{BufRead, BufReader, Read, Write};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, OnceLock};
+
+use super::{Backend, BackendMessage, CancelToken};
+
+/// Cached path to the codex binary.
+static CODEX_BINARY_PATH: OnceLock<Option<String>> = OnceLock::new();
+
+fn resolve_codex_binary_path() -> Option<String> {
+    // Priority: omx (Oh My Codex wrapper) > codex (direct CLI)
+    for bin_name in &["omx", "codex"] {
+        if let Ok(output) = Command::new("which").arg(bin_name).output() {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !path.is_empty() {
+                    return Some(path);
+                }
+            }
+        }
+
+        if let Ok(output) = Command::new("bash")
+            .args(["-lc", &format!("which {}", bin_name)])
+            .output()
+        {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !path.is_empty() {
+                    return Some(path);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn get_codex_binary_path() -> Option<&'static str> {
+    CODEX_BINARY_PATH
+        .get_or_init(resolve_codex_binary_path)
+        .as_deref()
+}
+
+/// Default allowed tools for Codex CLI
+pub const DEFAULT_ALLOWED_TOOLS: &[&str] = &[
+    "Bash",
+    "Read",
+    "Edit",
+    "Write",
+    "Glob",
+    "Grep",
+    "Task",
+    "TaskOutput",
+    "TaskStop",
+    "WebFetch",
+    "WebSearch",
+    "NotebookEdit",
+    "Skill",
+    "TaskCreate",
+    "TaskGet",
+    "TaskUpdate",
+    "TaskList",
+];
+
+const DEFAULT_SYSTEM_PROMPT: &str = r#"You are a terminal coding assistant running through Codex CLI.
+Be concise. Focus on practical, safe, non-interactive execution.
+Respond in the same language as the user.
+
+SECURITY RULES (MUST FOLLOW):
+- NEVER execute destructive commands like rm -rf, format, mkfs, dd, etc.
+- NEVER modify system files in /etc, /sys, /proc, /boot
+- NEVER execute commands that could harm the system or compromise security
+- If a request seems dangerous, explain the risk and suggest a safer alternative
+
+BASH EXECUTION RULES (MUST FOLLOW):
+- All commands MUST run non-interactively without user input
+- Use -y, --yes, or --non-interactive flags where applicable
+- Use -m flag for commit messages (e.g. git commit -m "message")
+- Disable pagers with --no-pager or pipe to cat
+- NEVER use commands that open editors (vim, nano, etc.)
+- NEVER use commands that wait for stdin without arguments
+- NEVER use interactive flags like -i"#;
+
+/// Validate session ID format (alphanumeric, dashes, underscores only, max 64 chars)
+fn is_valid_session_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 64
+        && id.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Parse one Codex JSONL event line into a BackendMessage.
+/// Codex uses a different event format from Claude stream-json.
+fn parse_codex_line(line: &str) -> Option<BackendMessage> {
+    let json: serde_json::Value = serde_json::from_str(line).ok()?;
+    let event_type = json.get("type").and_then(|v| v.as_str())?;
+
+    match event_type {
+        // Thread start — maps to Init
+        "thread.started" => {
+            let thread_id = json.get("thread_id").and_then(|v| v.as_str())?;
+            Some(BackendMessage::Init {
+                session_id: thread_id.to_string(),
+            })
+        }
+        // Tool invocation start
+        "item.started" => {
+            let item = json.get("item")?;
+            if item.get("type").and_then(|v| v.as_str()) == Some("command_execution") {
+                let command = item
+                    .get("command")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if !command.is_empty() {
+                    return Some(BackendMessage::ToolUse {
+                        name: "Bash".to_string(),
+                        input: command,
+                    });
+                }
+            }
+            None
+        }
+        // Item completed — agent message or command result
+        "item.completed" => {
+            let item = json.get("item")?;
+            match item.get("type").and_then(|v| v.as_str()) {
+                Some("agent_message") => {
+                    let text = item
+                        .get("text")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    if text.is_empty() {
+                        None
+                    } else {
+                        Some(BackendMessage::Text(text))
+                    }
+                }
+                Some("command_execution") => {
+                    let output = item
+                        .get("aggregated_output")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .trim_end()
+                        .to_string();
+                    let exit_code = item.get("exit_code").and_then(|v| v.as_i64());
+                    let is_error = exit_code.unwrap_or(0) != 0;
+
+                    if output.is_empty() && !is_error {
+                        return None;
+                    }
+
+                    let content = if !output.is_empty() {
+                        output
+                    } else {
+                        format!("Command exited with code {}", exit_code.unwrap_or(-1))
+                    };
+
+                    Some(BackendMessage::ToolResult { content, is_error })
+                }
+                Some("error") => {
+                    let message = item
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+
+                    if message.is_empty()
+                        || message.contains("Under-development features enabled")
+                    {
+                        None
+                    } else {
+                        Some(BackendMessage::Error(message))
+                    }
+                }
+                _ => None,
+            }
+        }
+        // Turn completed — maps to Complete
+        "turn.completed" => Some(BackendMessage::Complete {
+            response: String::new(),
+        }),
+        _ => None,
+    }
+}
+
+/// Build codex CLI arguments.
+fn codex_args(session_id: Option<&str>, working_dir: &str) -> Result<Vec<String>, String> {
+    let mut args = vec![
+        "-C".to_string(),
+        working_dir.to_string(),
+        "--sandbox".to_string(),
+        "danger-full-access".to_string(),
+        "-a".to_string(),
+        "never".to_string(),
+        "exec".to_string(),
+    ];
+
+    if let Some(sid) = session_id {
+        if !is_valid_session_id(sid) {
+            return Err("Invalid session ID format".to_string());
+        }
+        args.push("resume".to_string());
+        args.push(sid.to_string());
+        args.push("--json".to_string());
+        args.push("-".to_string());
+    } else {
+        args.push("--json".to_string());
+        args.push("--skip-git-repo-check".to_string());
+        args.push("-".to_string());
+    }
+
+    Ok(args)
+}
+
+/// AI backend that wraps the Codex CLI tool.
+pub struct CodexBackend;
+
+impl CodexBackend {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Returns true if the codex binary is available on PATH.
+    pub fn is_available() -> bool {
+        get_codex_binary_path().is_some()
+    }
+}
+
+impl Default for CodexBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl Backend for CodexBackend {
+    async fn execute_streaming(
+        &self,
+        prompt: &str,
+        session_id: Option<&str>,
+        working_dir: &str,
+        sender: tokio::sync::mpsc::Sender<BackendMessage>,
+        system_prompt: Option<&str>,
+        _allowed_tools: Option<&[String]>,
+        cancel_token: Option<Arc<CancelToken>>,
+    ) -> Result<(), String> {
+        let codex_bin = get_codex_binary_path()
+            .ok_or_else(|| "Codex CLI not found. Is Codex CLI installed?".to_string())?;
+
+        let args = codex_args(session_id, working_dir)?;
+
+        // Build the full prompt, optionally prepending system context
+        let effective_system_prompt = match system_prompt {
+            None => Some(DEFAULT_SYSTEM_PROMPT),
+            Some("") => None,
+            Some(p) => Some(p),
+        };
+
+        let full_prompt = if let Some(sp) = effective_system_prompt {
+            format!("SYSTEM:\n{}\n\n{}", sp, prompt)
+        } else {
+            prompt.to_string()
+        };
+
+        let prompt_owned = full_prompt;
+        let working_dir_owned = working_dir.to_string();
+        let codex_bin_owned = codex_bin.to_string();
+
+        let (sync_tx, mut sync_rx) = tokio::sync::mpsc::channel::<BackendMessage>(64);
+        let cancel_token_clone = cancel_token.clone();
+
+        tokio::task::spawn_blocking(move || {
+            let _ = run_codex_process(
+                &codex_bin_owned,
+                &args,
+                &prompt_owned,
+                &working_dir_owned,
+                sync_tx,
+                cancel_token_clone,
+            );
+        });
+
+        while let Some(msg) = sync_rx.recv().await {
+            if sender.send(msg).await.is_err() {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "codex"
+    }
+
+    fn binary_path(&self) -> Option<String> {
+        get_codex_binary_path().map(String::from)
+    }
+
+    fn default_allowed_tools(&self) -> Vec<String> {
+        DEFAULT_ALLOWED_TOOLS.iter().map(|s| s.to_string()).collect()
+    }
+}
+
+/// Synchronous worker that drives the codex process and emits BackendMessages.
+fn run_codex_process(
+    codex_bin: &str,
+    args: &[String],
+    prompt: &str,
+    working_dir: &str,
+    sender: tokio::sync::mpsc::Sender<BackendMessage>,
+    cancel_token: Option<Arc<CancelToken>>,
+) -> Result<(), String> {
+    let mut child = Command::new(codex_bin)
+        .args(args)
+        .current_dir(working_dir)
+        .env_remove("CLAUDECODE")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to start Codex: {}", e))?;
+
+    if let Some(ref token) = cancel_token {
+        token.set_child_pid(child.id());
+    }
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(prompt.as_bytes());
+    }
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Failed to capture stdout".to_string())?;
+
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Failed to capture stderr".to_string())?;
+
+    let stderr_handle = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let mut reader = BufReader::new(stderr);
+        let _ = reader.read_to_string(&mut buf);
+        buf
+    });
+
+    let mut reader = BufReader::new(stdout);
+    let mut line_buf = String::new();
+    let mut done_sent = false;
+
+    loop {
+        if let Some(ref token) = cancel_token {
+            if token.is_cancelled() {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Ok(());
+            }
+        }
+
+        line_buf.clear();
+        let read = reader
+            .read_line(&mut line_buf)
+            .map_err(|e| format!("Failed to read Codex output: {}", e))?;
+
+        if read == 0 {
+            break;
+        }
+
+        let line = line_buf.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if let Some(msg) = parse_codex_line(line) {
+            if matches!(msg, BackendMessage::Complete { .. }) {
+                done_sent = true;
+            }
+            if sender.blocking_send(msg).is_err() {
+                break;
+            }
+        }
+    }
+
+    if let Some(ref token) = cancel_token {
+        if token.is_cancelled() {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Ok(());
+        }
+    }
+
+    let status = child
+        .wait()
+        .map_err(|e| format!("Codex process wait failed: {}", e))?;
+
+    let stderr_output = stderr_handle.join().unwrap_or_default();
+
+    if !status.success() {
+        let error_msg = if !stderr_output.trim().is_empty() {
+            stderr_output.trim().to_string()
+        } else {
+            format!("Codex exited with code {:?}", status.code())
+        };
+        let _ = sender.blocking_send(BackendMessage::Error(error_msg));
+    }
+
+    if !done_sent {
+        let _ = sender.blocking_send(BackendMessage::Complete {
+            response: String::new(),
+        });
+    }
+
+    Ok(())
+}

--- a/src/services/backend/mod.rs
+++ b/src/services/backend/mod.rs
@@ -1,0 +1,119 @@
+pub mod claude;
+pub mod codex;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Global flag: when true, AI backends skip all permission checks.
+/// Set via `--madmax` CLI flag.
+static MADMAX_MODE: AtomicBool = AtomicBool::new(false);
+
+/// Enable madmax mode (skip all permission checks).
+pub fn set_madmax(enabled: bool) {
+    MADMAX_MODE.store(enabled, Ordering::Relaxed);
+}
+
+/// Check if madmax mode is active.
+pub fn is_madmax() -> bool {
+    MADMAX_MODE.load(Ordering::Relaxed)
+}
+
+/// Messages streamed from AI backend during execution
+#[derive(Debug, Clone)]
+pub enum BackendMessage {
+    /// Initialization - contains session_id
+    Init { session_id: String },
+    /// Text response chunk
+    Text(String),
+    /// Tool use started
+    ToolUse { name: String, input: String },
+    /// Tool execution result
+    ToolResult { content: String, is_error: bool },
+    /// Completion with final response
+    Complete { response: String },
+    /// Error
+    Error(String),
+}
+
+/// Token for cooperative cancellation of AI operations.
+/// Holds a flag and the child process PID so the caller can terminate it.
+pub struct CancelToken {
+    pub cancelled: std::sync::atomic::AtomicBool,
+    pub child_pid: std::sync::Mutex<Option<u32>>,
+}
+
+impl CancelToken {
+    pub fn new() -> Self {
+        Self {
+            cancelled: std::sync::atomic::AtomicBool::new(false),
+            child_pid: std::sync::Mutex::new(None),
+        }
+    }
+
+    pub fn cancel(&self) {
+        self.cancelled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        // Kill child process if tracked
+        if let Ok(guard) = self.child_pid.lock() {
+            if let Some(pid) = *guard {
+                #[cfg(unix)]
+                {
+                    unsafe {
+                        libc::kill(pid as libc::pid_t, libc::SIGTERM);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn set_child_pid(&self, pid: u32) {
+        if let Ok(mut guard) = self.child_pid.lock() {
+            *guard = Some(pid);
+        }
+    }
+}
+
+impl Default for CancelToken {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Trait for AI backend implementations.
+/// Each backend wraps a specific AI CLI tool (Claude, Codex, etc.)
+/// and exposes a unified streaming execution interface.
+#[async_trait::async_trait]
+pub trait Backend: Send + Sync {
+    /// Execute a prompt with streaming output.
+    ///
+    /// Messages are sent to `sender` as they arrive. The function returns
+    /// once the underlying process completes or is cancelled.
+    async fn execute_streaming(
+        &self,
+        prompt: &str,
+        session_id: Option<&str>,
+        working_dir: &str,
+        sender: tokio::sync::mpsc::Sender<BackendMessage>,
+        system_prompt: Option<&str>,
+        allowed_tools: Option<&[String]>,
+        cancel_token: Option<Arc<CancelToken>>,
+    ) -> Result<(), String>;
+
+    /// Human-readable name of this backend (e.g. "claude", "codex").
+    fn name(&self) -> &str;
+
+    /// Resolve the path to the backend binary, if available.
+    fn binary_path(&self) -> Option<String>;
+
+    /// Default set of tools this backend exposes.
+    fn default_allowed_tools(&self) -> Vec<String>;
+}
+
+pub use claude::ClaudeBackend;
+pub use codex::CodexBackend;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod backend;
 pub mod file_ops;
 pub mod process;
 pub mod claude;

--- a/src/services/telegram.rs
+++ b/src/services/telegram.rs
@@ -10,6 +10,8 @@ use teloxide::prelude::*;
 use teloxide::types::ParseMode;
 use sha2::{Sha256, Digest};
 
+// Future: Replace direct claude:: calls with Backend trait dispatch
+// use crate::services::backend::{Backend, ClaudeBackend, CodexBackend};
 use crate::services::claude::{self, CancelToken, StreamMessage, DEFAULT_ALLOWED_TOOLS};
 use crate::ui::ai_screen::{self, HistoryItem, HistoryType, SessionData};
 


### PR DESCRIPTION
## 요약

  AI 백엔드를 쉽게 교체/추가할 수 있도록 공통 인터페이스(Backend trait)를 만들고,
  Claude와 Codex 두 가지 구현체를 추가했습니다.
  새로운 CLI 플래그 --openclaude, --opencodex, --madmax도 함께 추가했습니다.

  ## 배경

  현재 텔레그램 봇은 Claude에 직접 연결되어 있습니다.
  다른 AI를 추가하려면 봇 코드 전체를 수정해야 합니다.

  이 PR은 "AI 백엔드"라는 공통 규격을 만들어서,
  새로운 AI를 추가할 때 규격에 맞는 파일 하나만 만들면 되게 합니다.

  쉽게 비유하면:
  - 기존: 봇 → Claude (직접 연결, 교체 불가)
  - 변경: 봇 → Backend 규격 → Claude / Codex / 미래의 다른 AI

  ## 추가된 기능

  ### 1. Backend trait (공통 인터페이스)
  모든 AI 백엔드가 구현해야 하는 규격:
  - execute_streaming() — AI에게 질문하고 답변을 스트리밍으로 받기
  - name() — 백엔드 이름 (예: "claude", "codex")
  - binary_path() — CLI 실행 파일 경로 자동 탐색
  - default_allowed_tools() — 기본 허용 도구 목록

  ### 2. ClaudeBackend
  기존 Claude 연결 코드를 Backend 규격에 맞게 감싼 구현체

  ### 3. CodexBackend
  - OpenAI Codex CLI를 연결하는 새로운 구현체
  - Codex가 보내는 JSONL 형식을 파싱하여 통합 메시지 형식으로 변환
  - omx (Oh My Codex) 자동 감지: omx가 설치되어 있으면 omx를 사용, 없으면 codex를 직접 사용

  ### 4. CancelToken
  AI 응답 도중 /stop을 누르면 실행 중인 프로세스를 즉시 종료

  ### 5. 새로운 CLI 플래그

  | 플래그 | 설명 |
  |--------|------|
  | --openclaude <TOKEN> | Claude 백엔드로 텔레그램 봇 실행 (--ccserver와 동일) |
  | --opencodex <TOKEN> | Codex 백엔드로 텔레그램 봇 실행 |
  | --madmax | AI 권한 체크를 모두 건너뜀 (주의해서 사용) |
  | --ccserver <TOKEN> | 기존과 동일하게 동작 (하위 호환) |

  ### --opencodex 바이너리 자동 감지
  1. omx가 설치되어 있으면 → omx 사용 (Oh My Codex 래퍼)
  2. omx가 없으면 → codex 직접 사용
  3. 둘 다 없으면 → 에러 메시지 + 설치 안내

  ### --madmax 모드
  - 있을 때: claude --dangerously-skip-permissions (모든 확인 건너뜀)
  - 없을 때: claude --permission-mode default (파일 수정/명령 실행 시 확인)

  ## 사용 예시

  ```bash
  # Claude 백엔드로 봇 실행 (일반 모드)
  ./cokacdir --openclaude 텔레그램토큰

  # Claude 백엔드 + 권한 체크 건너뛰기
  ./cokacdir --openclaude 텔레그램토큰 --madmax

  # Codex 백엔드로 봇 실행 (omx 자동 감지)
  ./cokacdir --opencodex 텔레그램토큰

  # 기존 방식도 그대로 동작
  ./cokacdir --ccserver 텔레그램토큰

  모듈 구조

  src/services/backend/
  ├── mod.rs      — Backend trait, BackendMessage, CancelToken, madmax 플래그
  ├── claude.rs   — ClaudeBackend 구현
  └── codex.rs    — CodexBackend 구현 (omx 우선 감지)

  변경 파일

  - src/services/backend/mod.rs — 신규 (trait + 공통 타입 + madmax 플래그)
  - src/services/backend/claude.rs — 신규 (Claude 구현)
  - src/services/backend/codex.rs — 신규 (Codex/omx 구현)
  - src/services/mod.rs — backend 모듈 선언 추가
  - src/main.rs — --openclaude, --opencodex, --madmax 플래그 + help 업데이트
