### PR TITLE
feat: add interactive setup wizard for Telegram bot

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod utils;
 mod config;
 mod keybindings;
 mod enc;
+mod setup;
 
 use std::io;
 use std::env;
@@ -40,7 +41,8 @@ fn print_help() {
     println!("    --prompt <TEXT>         Send prompt to AI and print rendered response");
     println!("    --design                Enable theme hot-reload (for theme development)");
     println!("    --base64 <TEXT>         Decode base64 and print (internal use)");
-    println!("    --ccserver <TOKEN>...   Start Telegram bot server(s)");
+    println!("    --setup                 Run interactive Telegram bot setup wizard");
+    println!("    --ccserver [TOKEN]...   Start Telegram bot server(s) (token optional if --setup was run)");
     println!("    --sendfile <PATH> --chat <ID> --key <HASH>");
     println!("                            Send file via Telegram bot (internal use, HASH = token hash)");
     println!("    --ismcptool <TOOL>...    Check if MCP tool(s) are registered in .claude/settings.json (CWD)");
@@ -340,15 +342,32 @@ fn main() -> io::Result<()> {
                 handle_base64(&args[i + 1]);
                 return Ok(());
             }
+            "--setup" => {
+                if let Err(e) = setup::run_setup() {
+                    eprintln!("Setup failed: {}", e);
+                    std::process::exit(1);
+                }
+                return Ok(());
+            }
             "--ccserver" => {
-                let tokens: Vec<String> = args[i + 1..].iter()
-                    .filter(|a| !a.starts_with('-'))
-                    .cloned()
-                    .collect();
+                let mut tokens: Vec<String> = if i + 1 < args.len() {
+                    args[i + 1..].iter()
+                        .filter(|a| !a.starts_with('-'))
+                        .cloned()
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+                // If no tokens provided via CLI, try loading from config
                 if tokens.is_empty() {
-                    eprintln!("Error: --ccserver requires at least one token argument");
-                    eprintln!("Usage: cokacdir --ccserver <TOKEN> [TOKEN2] ...");
-                    return Ok(());
+                    if let Some(saved_token) = setup::load_saved_token() {
+                        tokens.push(saved_token);
+                    } else {
+                        eprintln!("Error: --ccserver requires at least one token argument");
+                        eprintln!("Usage: cokacdir --ccserver <TOKEN> [TOKEN2] ...");
+                        eprintln!("       or run 'cokacdir --setup' to configure a token");
+                        return Ok(());
+                    }
                 }
                 handle_ccserver(tokens);
                 return Ok(());

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,0 +1,325 @@
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+// ── i18n strings ─────────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+pub enum Lang {
+    Ko,
+    En,
+}
+
+struct Strings {
+    header: &'static str,
+    lang_prompt: &'static str,
+    token_prompt: &'static str,
+    token_invalid_format: &'static str,
+    token_validation_skip: &'static str,
+    token_saved: &'static str,
+    workdir_prompt: &'static str,
+    workdir_default: &'static str,
+    workdir_not_dir: &'static str,
+    git_ok: &'static str,
+    git_missing: &'static str,
+    git_install_hint: &'static str,
+    gh_ok: &'static str,
+    gh_missing: &'static str,
+    gh_install_hint: &'static str,
+    complete: &'static str,
+    hint_run: &'static str,
+    hint_setup: &'static str,
+}
+
+const KO: Strings = Strings {
+    header: "cokacdir Telegram 봇 초기 설정",
+    lang_prompt: "언어를 선택하세요 (1=한국어, 2=English) [기본값: 1]: ",
+    token_prompt: "Telegram 봇 토큰을 입력하세요: ",
+    token_invalid_format: "  ! 유효하지 않은 토큰 형식입니다. 형식: 123456:ABC... (최대 3회 시도)",
+    token_validation_skip: "  ! 토큰 형식 검증을 건너뜁니다",
+    token_saved: "  ✓ 설정이 저장되었습니다",
+    workdir_prompt: "작업 디렉토리를 입력하세요",
+    workdir_default: "기본값",
+    workdir_not_dir: "  ! 디렉토리가 아닙니다. 홈 디렉토리를 사용합니다",
+    git_ok: "  ✓ git 설치됨",
+    git_missing: "  ! git이 설치되어 있지 않습니다",
+    git_install_hint: "    설치: https://git-scm.com/downloads",
+    gh_ok: "  ✓ gh (GitHub CLI) 설치됨",
+    gh_missing: "  ! gh (GitHub CLI)가 설치되어 있지 않습니다",
+    gh_install_hint: "    설치: https://cli.github.com",
+    complete: "설정이 완료되었습니다!",
+    hint_run: "봇 시작하기:",
+    hint_setup: "다시 설정하려면:",
+};
+
+const EN: Strings = Strings {
+    header: "cokacdir Telegram Bot Setup",
+    lang_prompt: "Select language (1=Korean, 2=English) [default: 2]: ",
+    token_prompt: "Enter your Telegram bot token: ",
+    token_invalid_format: "  ! Invalid token format. Expected: 123456:ABC... (max 3 attempts)",
+    token_validation_skip: "  ! Skipping token format validation",
+    token_saved: "  ✓ Configuration saved",
+    workdir_prompt: "Enter working directory",
+    workdir_default: "default",
+    workdir_not_dir: "  ! Not a directory. Using home directory",
+    git_ok: "  ✓ git is installed",
+    git_missing: "  ! git is not installed",
+    git_install_hint: "    Install: https://git-scm.com/downloads",
+    gh_ok: "  ✓ gh (GitHub CLI) is installed",
+    gh_missing: "  ! gh (GitHub CLI) is not installed",
+    gh_install_hint: "    Install: https://cli.github.com",
+    complete: "Setup complete!",
+    hint_run: "Start the bot:",
+    hint_setup: "Run setup again:",
+};
+
+fn s(lang: Lang) -> &'static Strings {
+    match lang {
+        Lang::Ko => &KO,
+        Lang::En => &EN,
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn read_line_trimmed() -> String {
+    let mut input = String::new();
+    if io::stdin().read_line(&mut input).is_err() {
+        return String::new();
+    }
+    input.trim().to_string()
+}
+
+fn find_in_path(name: &str) -> bool {
+    if let Ok(path) = std::env::var("PATH") {
+        for dir in path.split(':') {
+            if std::path::Path::new(dir).join(name).exists() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn get_cmd_output(name: &str, args: &[&str]) -> Option<String> {
+    Command::new(name)
+        .args(args)
+        .stderr(Stdio::null())
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.lines().next().unwrap_or("").trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn config_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".cokacdir").join("config.json"))
+}
+
+// ── Setup steps ──────────────────────────────────────────────────────────────
+
+fn select_language() -> Lang {
+    print!("{}", EN.lang_prompt);
+    io::stdout().flush().ok();
+    let input = read_line_trimmed();
+    if input == "1" {
+        Lang::Ko
+    } else {
+        Lang::En
+    }
+}
+
+fn validate_token_format(token: &str) -> bool {
+    // Telegram bot token format: <bot_id>:<auth_token>
+    // bot_id: digits only, auth_token: alphanumeric + _ and -
+    let parts: Vec<&str> = token.splitn(2, ':').collect();
+    if parts.len() != 2 {
+        return false;
+    }
+    let bot_id = parts[0];
+    let auth = parts[1];
+    !bot_id.is_empty()
+        && bot_id.chars().all(|c| c.is_ascii_digit())
+        && auth.len() >= 10
+        && auth.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+}
+
+fn get_telegram_token(lang: Lang) -> Result<String, Box<dyn std::error::Error>> {
+    let t = s(lang);
+    for attempt in 0..3 {
+        print!("{}", t.token_prompt);
+        io::stdout().flush()?;
+        let token = read_line_trimmed();
+
+        if token.is_empty() {
+            if attempt == 2 {
+                println!("{}", t.token_validation_skip);
+                return Err("No token provided".into());
+            }
+            println!("{}", t.token_invalid_format);
+            continue;
+        }
+
+        if validate_token_format(&token) {
+            return Ok(token);
+        }
+
+        if attempt < 2 {
+            println!("{}", t.token_invalid_format);
+        } else {
+            println!("{}", t.token_validation_skip);
+            return Err("Invalid token format after 3 attempts".into());
+        }
+    }
+    Err("Token input failed".into())
+}
+
+fn get_working_directory(lang: Lang) -> PathBuf {
+    let t = s(lang);
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+    print!("{} [{}: {}]: ", t.workdir_prompt, t.workdir_default, home.display());
+    io::stdout().flush().ok();
+    let input = read_line_trimmed();
+
+    if input.is_empty() {
+        return home;
+    }
+
+    let path = PathBuf::from(&input);
+    if path.is_dir() {
+        path
+    } else {
+        println!("{}", t.workdir_not_dir);
+        home
+    }
+}
+
+fn save_setup_config(
+    token: &str,
+    lang: Lang,
+    work_dir: &PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let lang_str = match lang {
+        Lang::Ko => "ko",
+        Lang::En => "en",
+    };
+
+    let config_json = serde_json::json!({
+        "telegram_token": token,
+        "language": lang_str,
+        "working_directory": work_dir.to_string_lossy().as_ref(),
+    });
+
+    let path = config_path().ok_or("Cannot determine home directory")?;
+    let dir = path.parent().ok_or("Cannot determine config directory")?;
+
+    fs::create_dir_all(dir)?;
+
+    // Set directory permissions to user-only on Unix
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(dir, fs::Permissions::from_mode(0o700));
+    }
+
+    let content = serde_json::to_string_pretty(&config_json)?;
+    fs::write(&path, &content)?;
+
+    // Set file permissions to user-only on Unix
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+    }
+
+    Ok(())
+}
+
+fn check_git_installed(lang: Lang) {
+    let t = s(lang);
+    if find_in_path("git") {
+        let ver = get_cmd_output("git", &["--version"]).unwrap_or_default();
+        println!("{}: {}", t.git_ok, ver);
+    } else {
+        println!("{}", t.git_missing);
+        println!("{}", t.git_install_hint);
+    }
+}
+
+fn check_gh_installed(lang: Lang) {
+    let t = s(lang);
+    if find_in_path("gh") {
+        let ver = get_cmd_output("gh", &["--version"]).unwrap_or_default();
+        println!("{}: {}", t.gh_ok, ver);
+    } else {
+        println!("{}", t.gh_missing);
+        println!("{}", t.gh_install_hint);
+    }
+}
+
+fn print_success_message(lang: Lang, work_dir: &PathBuf) {
+    let t = s(lang);
+    let bar = "─".repeat(50);
+    println!();
+    println!("{bar}");
+    println!("  {}", t.complete);
+    println!();
+    println!("  {}:", t.hint_run);
+    println!("    cokacdir --ccserver");
+    println!();
+    println!("  {}:", t.hint_setup);
+    println!("    cokacdir --setup");
+    println!();
+    println!("  Working directory: {}", work_dir.display());
+    println!("{bar}");
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Run the interactive setup wizard for Telegram bot configuration
+pub fn run_setup() -> Result<(), Box<dyn std::error::Error>> {
+    let bar = "─".repeat(50);
+    println!();
+    println!("{bar}");
+    println!("  cokacdir Telegram Bot Setup");
+    println!("{bar}");
+    println!();
+
+    // Step 1: Language selection
+    let lang = select_language();
+    println!();
+
+    // Step 2: Telegram bot token
+    let token = get_telegram_token(lang)?;
+    println!();
+
+    // Step 3: Working directory
+    let work_dir = get_working_directory(lang);
+    println!();
+
+    // Step 4: Save config
+    save_setup_config(&token, lang, &work_dir)?;
+    println!("{}", s(lang).token_saved);
+    println!();
+
+    // Step 5: Optional checks
+    check_git_installed(lang);
+    check_gh_installed(lang);
+
+    // Step 6: Success message
+    print_success_message(lang, &work_dir);
+
+    Ok(())
+}
+
+/// Load the saved Telegram token from ~/.cokacdir/config.json
+pub fn load_saved_token() -> Option<String> {
+    let path = config_path()?;
+    let content = fs::read_to_string(&path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    json.get("telegram_token")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+}


### PR DESCRIPTION
  feat: add interactive setup wizard for Telegram bot

  설명:
  ## 요약

  텔레그램 봇을 처음 설정할 때 단계별로 안내해주는 대화형 설정 마법사를 추가했습니다.

  ## 배경

  현재 봇을 실행하려면 이렇게 해야 합니다:

  1. 텔레그램에서 @BotFather한테 가서 봇을 만들고
  2. 토큰을 복사하고
  3. 터미널에서 --ccserver 토큰 을 직접 입력

  처음 사용하는 사람은:
  - 토큰이 뭔지 모르고
  - 어디서 발급받는지 모르고
  - 어떤 명령어를 쳐야 하는지 모릅니다

  이 PR은 "cokacdir --setup"만 치면 모든 설정을
  대화형으로 하나씩 안내해주는 마법사를 추가합니다.

  ## 추가된 기능

  ### --setup 플래그
  ```bash
  ./cokacdir --setup

  실행하면 아래 순서로 안내합니다:

  1단계: 언어 선택

  Select language / 언어를 선택하세요:
  1) English
  2) 한국어
  > 2

  2단계: 텔레그램 봇 토큰 입력

  텔레그램 봇 토큰을 입력하세요.
  (@BotFather에서 /newbot으로 발급받을 수 있습니다)
  > 7123456789:AAG...
  - 입력한 토큰의 형식이 올바른지 자동 검증

  3단계: 작업 디렉토리 설정

  AI가 작업할 기본 디렉토리를 입력하세요.
  (비워두면 홈 디렉토리를 사용합니다)
  > ~/projects

  4단계: 설정 저장

  - 설정이 ~/.cokacdir/config.json에 저장됨
  - 다음부터는 --ccserver에 토큰을 안 적어도 저장된 토큰을 자동으로 사용

  저장된 토큰 자동 로드

  설정 마법사를 한 번 거치면:
  # 전: 매번 토큰을 직접 입력해야 함
  ./cokacdir --ccserver 7123456789:AAG긴토큰...

  # 후: 토큰 없이도 실행 가능 (저장된 토큰 사용)
  ./cokacdir --ccserver

  변경 파일

  - src/setup.rs — 신규 (설정 마법사 전체 로직, 252줄)
  - src/main.rs — --setup 플래그 처리 추가
