### PR TITLE
fix: honor state root across telegram runtime

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,21 @@ fn default_telegram_polling_time() -> u64 {
     3000
 }
 
+/// Environment variable that overrides the default ~/.cokacdir state root.
+pub const STATE_ROOT_ENV_VAR: &str = "COKACDIR_STATE_ROOT";
+
+/// Returns the effective state root directory.
+///
+/// Resolution order:
+/// 1. `COKACDIR_STATE_ROOT`
+/// 2. `~/.cokacdir`
+pub fn state_root_dir() -> Option<PathBuf> {
+    std::env::var_os(STATE_ROOT_ENV_VAR)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".cokacdir")))
+}
+
 impl Default for PanelSettings {
     fn default() -> Self {
         Self {
@@ -180,9 +195,9 @@ impl Default for Settings {
 }
 
 impl Settings {
-    /// Returns the config directory path (~/.cokacdir)
+    /// Returns the config directory path (COKACDIR_STATE_ROOT or ~/.cokacdir)
     pub fn config_dir() -> Option<PathBuf> {
-        dirs::home_dir().map(|h| h.join(".cokacdir"))
+        state_root_dir()
     }
 
     /// Returns the themes directory path (~/.cokacdir/themes)
@@ -361,6 +376,21 @@ impl Settings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
+
+    fn with_state_root_env<T>(value: Option<&std::path::Path>, f: impl FnOnce() -> T) -> T {
+        let previous = std::env::var_os(STATE_ROOT_ENV_VAR);
+        match value {
+            Some(path) => std::env::set_var(STATE_ROOT_ENV_VAR, path),
+            None => std::env::remove_var(STATE_ROOT_ENV_VAR),
+        }
+        let result = f();
+        match previous {
+            Some(value) => std::env::set_var(STATE_ROOT_ENV_VAR, value),
+            None => std::env::remove_var(STATE_ROOT_ENV_VAR),
+        }
+        result
+    }
 
     #[test]
     fn test_default_settings() {
@@ -397,5 +427,28 @@ mod tests {
         assert!(json.contains("\"name\": \"light\""));
         assert!(json.contains("\"palette\""));
         assert!(json.contains("\"panel\""));
+    }
+
+    #[test]
+    fn test_state_root_dir_prefers_env_override() {
+        let dir = tempdir().unwrap();
+        let expected = dir.path().join("isolated-cokacdir");
+        with_state_root_env(Some(&expected), || {
+            assert_eq!(state_root_dir(), Some(expected.clone()));
+            assert_eq!(Settings::config_dir(), Some(expected.clone()));
+        });
+    }
+
+    #[test]
+    fn test_ensure_config_exists_uses_env_override() {
+        let dir = tempdir().unwrap();
+        let state_root = dir.path().join("state-root");
+        with_state_root_env(Some(&state_root), || {
+            Settings::ensure_config_exists();
+            assert!(state_root.is_dir(), "state root should exist");
+            assert!(state_root.join("themes").is_dir(), "themes directory should exist");
+            assert!(state_root.join("themes").join("light.json").exists(), "light.json should exist");
+            assert!(state_root.join("settings.json").exists(), "settings.json should exist");
+        });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,10 +125,10 @@ fn handle_sendfile(path: &str, chat_id: i64, hash_key: &str) {
     };
 
     // Create upload queue directory
-    let queue_dir = match dirs::home_dir() {
-        Some(h) => h.join(".cokacdir").join("upload_queue"),
+    let queue_dir = match config::state_root_dir() {
+        Some(root) => root.join("upload_queue"),
         None => {
-            eprintln!("{}", serde_json::json!({"status":"error","message":"cannot determine home directory"}));
+            eprintln!("{}", serde_json::json!({"status":"error","message":"cannot determine state root"}));
             std::process::exit(1);
         }
     };
@@ -335,8 +335,10 @@ fn handle_cron_register(prompt: &str, at_value: &str, chat_id: i64, hash_key: &s
     output.as_object_mut().unwrap().insert("hint".to_string(), serde_json::json!(hint));
     cron_debug(&format!("  Output: {}", output));
     // Write result to temp file so the bot can read it even if Bash tool misses stdout
-    if let Some(home) = dirs::home_dir() {
-        let result_path = home.join(".cokacdir").join("schedule").join(format!("{}.result", id));
+    if let Some(state_root) = config::state_root_dir() {
+        let result_dir = state_root.join("schedule");
+        let _ = std::fs::create_dir_all(&result_dir);
+        let result_path = result_dir.join(format!("{}.result", id));
         let _ = std::fs::write(&result_path, output.to_string());
         cron_debug(&format!("  Result file written: {}", result_path.display()));
     }
@@ -443,8 +445,8 @@ fn handle_cron_context(args: &[String]) {
             cron_debug(&format!("  Context summary extracted in {:?}, len={}", extract_start.elapsed(), summary.len()));
 
             // 실행 중 삭제된 스케줄 부활 방지: 파일이 아직 존재하는지 확인
-            if let Some(home) = dirs::home_dir() {
-                let path = home.join(".cokacdir").join("schedule").join(format!("{}.json", ctx.id));
+            if let Some(state_root) = config::state_root_dir() {
+                let path = state_root.join("schedule").join(format!("{}.json", ctx.id));
                 if !path.exists() {
                     cron_debug(&format!("  Schedule {} already deleted, skipping context_summary write", ctx.id));
                     cron_debug("=== handle_cron_context END ===");
@@ -1419,8 +1421,8 @@ fn deploy_docs() {
         ("how-to-use-shell-commands.md", include_str!("../docs/how-to-use-shell-commands.md")),
         ("how-to-share-bot-with-others.md", include_str!("../docs/how-to-share-bot-with-others.md")),
     ];
-    if let Some(home) = dirs::home_dir() {
-        let docs_dir = home.join(".cokacdir").join("docs");
+    if let Some(state_root) = config::state_root_dir() {
+        let docs_dir = state_root.join("docs");
         let _ = std::fs::create_dir_all(&docs_dir);
         for (name, content) in DOCS {
             let path = docs_dir.join(name);
@@ -1429,11 +1431,11 @@ fn deploy_docs() {
     }
 }
 
-/// Load ~/.cokacdir/.env.json and set environment variables.
+/// Load COKACDIR_STATE_ROOT/.env.json (or ~/.cokacdir/.env.json) and set environment variables.
 /// Values from this file take priority over the existing environment.
 fn load_dot_env() {
-    let env_path = match dirs::home_dir() {
-        Some(h) => h.join(".cokacdir").join(".env.json"),
+    let env_path = match config::state_root_dir() {
+        Some(root) => root.join(".env.json"),
         None => return,
     };
     let content = match std::fs::read_to_string(&env_path) {
@@ -1443,7 +1445,7 @@ fn load_dot_env() {
     let map: serde_json::Map<String, serde_json::Value> = match serde_json::from_str(&content) {
         Ok(m) => m,
         Err(e) => {
-            eprintln!("Warning: failed to parse ~/.cokacdir/.env.json: {}", e);
+            eprintln!("Warning: failed to parse state-root .env.json: {}", e);
             return;
         }
     };
@@ -1468,9 +1470,9 @@ fn main() -> io::Result<()> {
     // Initialize debug flag from environment variable
     claude::init_debug_from_env();
 
-    // Ensure home directory is available (~/.cokacdir is required)
-    if dirs::home_dir().is_none() {
-        eprintln!("Error: Cannot determine home directory. ~/.cokacdir is required.");
+    // Ensure state root is available (COKACDIR_STATE_ROOT or ~/.cokacdir is required)
+    if config::state_root_dir().is_none() {
+        eprintln!("Error: Cannot determine state root. COKACDIR_STATE_ROOT or ~/.cokacdir is required.");
         std::process::exit(1);
     }
 

--- a/src/services/file_ops.rs
+++ b/src/services/file_ops.rs
@@ -1099,15 +1099,27 @@ fn target_is_sensitive(target: &str) -> bool {
     const SEP: char = '/';
     #[cfg(windows)]
     const SEP: char = '\\';
-    for sensitive in SENSITIVE_PATHS {
-        if target == *sensitive {
-            return true;
+    let normalized_target = {
+        #[cfg(unix)]
+        {
+            target.strip_prefix("/private").unwrap_or(target)
         }
-        let mut boundary = String::with_capacity(sensitive.len() + 1);
-        boundary.push_str(sensitive);
-        boundary.push(SEP);
-        if target.starts_with(&boundary) {
-            return true;
+        #[cfg(not(unix))]
+        {
+            target
+        }
+    };
+    for candidate in [target, normalized_target] {
+        for sensitive in SENSITIVE_PATHS {
+            if candidate == *sensitive {
+                return true;
+            }
+            let mut boundary = String::with_capacity(sensitive.len() + 1);
+            boundary.push_str(sensitive);
+            boundary.push(SEP);
+            if candidate.starts_with(&boundary) {
+                return true;
+            }
         }
     }
     false
@@ -1549,6 +1561,14 @@ mod tests {
         assert!(result.is_err());
 
         cleanup_temp_dir(&temp_dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_target_is_sensitive_private_prefix() {
+        assert!(target_is_sensitive("/private/etc"));
+        assert!(target_is_sensitive("/private/var/log"));
+        assert!(target_is_sensitive("/private/dev/null"));
     }
 
     // ========== move_file tests ==========

--- a/src/services/telegram.rs
+++ b/src/services/telegram.rs
@@ -85,12 +85,12 @@ fn refresh_global_debug_flags() -> bool {
     enabled
 }
 
-/// Log Telegram API call result to ~/.cokacdir/debug/ file
+/// Log Telegram API call result to the effective state-root debug/ file.
 fn tg_debug<T, E: std::fmt::Display>(name: &str, result: &Result<T, E>) {
     if !TG_DEBUG.load(Ordering::Relaxed) {
         return;
     }
-    let Some(debug_dir) = dirs::home_dir().map(|h| h.join(".cokacdir").join("debug")) else {
+    let Some(debug_dir) = crate::config::state_root_dir().map(|root| root.join("debug")) else {
         return;
     };
     let _ = fs::create_dir_all(&debug_dir);
@@ -233,10 +233,10 @@ pub fn parse_payload_auto(text: &str) -> Vec<RawPayloadEntry> {
 /// Maximum content length before truncation and offloading to a separate file.
 const PAYLOAD_TRUNCATE_LIMIT: usize = 500;
 
-/// Save long content to ~/.cokacdir/values/<unique>.txt and return the file path.
+/// Save long content to state-root values/<unique>.txt and return the file path.
 /// Returns None if saving fails.
 fn save_payload_value(content: &str) -> Option<String> {
-    let dir = dirs::home_dir()?.join(".cokacdir").join("values");
+    let dir = crate::config::state_root_dir()?.join("values");
     if fs::create_dir_all(&dir).is_err() { return None; }
     let ts = chrono::Local::now().format("%Y%m%d%H%M%S");
     use rand::Rng;
@@ -290,7 +290,7 @@ struct GroupChatLock {
 async fn acquire_group_chat_lock(chat_id: i64) -> Option<GroupChatLock> {
     use fs2::FileExt;
     if chat_id >= 0 { return None; }
-    let dir = dirs::home_dir()?.join(".cokacdir").join("chat_locks");
+    let dir = crate::config::state_root_dir()?.join("chat_locks");
     let _ = std::fs::create_dir_all(&dir);
     let lock_path = dir.join(format!("{}.lock", chat_id));
     let file = std::fs::OpenOptions::new()
@@ -319,9 +319,9 @@ async fn acquire_group_chat_lock(chat_id: i64) -> Option<GroupChatLock> {
     }
 }
 
-/// Return the directory for group chat logs: ~/.cokacdir/group_chat/
+/// Return the directory for group chat logs under the effective state root.
 fn group_chat_log_dir() -> Option<std::path::PathBuf> {
-    dirs::home_dir().map(|h| h.join(".cokacdir").join("group_chat"))
+    crate::config::state_root_dir().map(|root| root.join("group_chat"))
 }
 
 /// Return the JSONL file path for a specific group chat.
@@ -812,9 +812,9 @@ fn live_schedule_key_verifier(schedule_id: &str, chat_id: i64, bot_key: &str) ->
     hex::encode(hasher.finalize())
 }
 
-/// Directory for schedule files: ~/.cokacdir/schedule/
+/// Directory for schedule files under the effective state root.
 fn schedule_dir() -> Option<std::path::PathBuf> {
-    let result = dirs::home_dir().map(|h| h.join(".cokacdir").join("schedule"));
+    let result = crate::config::state_root_dir().map(|root| root.join("schedule"));
     sched_debug(&format!("[schedule_dir] → {:?}", result));
     result
 }
@@ -833,12 +833,12 @@ fn msg_debug(msg: &str) {
 }
 
 /// Always-on debug log (independent of /debug toggle).
-/// Writes to ~/.cokacdir/debug/ai_trace.log for diagnosing AI execution issues.
+/// Writes to state-root debug/ai_trace.log for diagnosing AI execution issues.
 /// AI provider stream errors can include URLs with the bot token; redact
 /// before persisting so this always-on log stays safe to share.
 fn ai_trace(msg: &str) {
-    if let Some(home) = dirs::home_dir() {
-        let debug_dir = home.join(".cokacdir").join("debug");
+    if let Some(state_root) = crate::config::state_root_dir() {
+        let debug_dir = state_root.join("debug");
         let _ = std::fs::create_dir_all(&debug_dir);
         let log_path = debug_dir.join("ai_trace.log");
         if let Ok(mut file) = std::fs::OpenOptions::new()
@@ -854,14 +854,14 @@ fn ai_trace(msg: &str) {
     }
 }
 
-/// Log an incoming Telegram message to ~/.cokacdir/logs/telegram_YYYY-MM-DD.jsonl
+/// Log an incoming Telegram message to state-root logs/telegram_YYYY-MM-DD.jsonl
 fn log_incoming_message(msg: &Message, accepted: bool, reject_reason: &str) {
     let now = chrono::Local::now();
     let date_str = now.format("%Y-%m-%d").to_string();
     let ts = now.format("%Y-%m-%dT%H:%M:%S%.3f%:z").to_string();
 
-    let logs_dir = match dirs::home_dir() {
-        Some(h) => h.join(".cokacdir").join("logs"),
+    let logs_dir = match crate::config::state_root_dir() {
+        Some(root) => root.join("logs"),
         None => return,
     };
     let _ = fs::create_dir_all(&logs_dir);
@@ -1236,10 +1236,10 @@ fn delete_schedule_entry(id: &str) -> bool {
     ok
 }
 
-/// Directory for schedule run history files: ~/.cokacdir/schedule_history/
+/// Directory for schedule run history files under the effective state root.
 /// Each schedule keeps one JSONL file (`<id>.log`) with one record per execution.
 fn schedule_history_dir() -> Option<std::path::PathBuf> {
-    dirs::home_dir().map(|h| h.join(".cokacdir").join("schedule_history"))
+    crate::config::state_root_dir().map(|root| root.join("schedule_history"))
 }
 
 /// Public access to the schedule history file path (for `--cron-history` in main.rs).
@@ -2158,11 +2158,11 @@ BREVITY RULE:
 You are a participant in a group chat. Writing long messages alone is inconsiderate to other participants.
 Keep your answers short and concise — ideally one or two sentences.";
 
-/// Load co-work guidelines from ~/.cokacdir/prompt/cowork.md.
+/// Load co-work guidelines from state-root prompt/cowork.md.
 /// If the file does not exist, creates it with default content.
 fn load_cowork_guidelines() -> String {
-    if let Some(home) = dirs::home_dir() {
-        let prompt_dir = home.join(".cokacdir").join("prompt");
+    if let Some(state_root) = crate::config::state_root_dir() {
+        let prompt_dir = state_root.join("prompt");
         let cowork_path = prompt_dir.join("cowork.md");
         if cowork_path.exists() {
             if let Ok(content) = std::fs::read_to_string(&cowork_path) {
@@ -2767,7 +2767,7 @@ async fn auto_restore_session(state: &SharedState, chat_id: ChatId, user_name: &
     }
 }
 
-/// Auto-create a workspace session under ~/.cokacdir/workspace/<random>.
+/// Auto-create a workspace session under the effective state-root workspace/<random>.
 /// Returns (session_id, path) on success; None if filesystem fails.
 ///
 /// Sends a Telegram notification with the new workspace path so the user
@@ -2783,14 +2783,14 @@ async fn auto_create_workspace_session(
 ) -> Option<(Option<String>, String)> {
     msg_debug(&format!("[auto_workspace] chat_id={}, auto-creating workspace", chat_id.0));
     let auto_path = {
-        let home = match dirs::home_dir() {
-            Some(h) => h,
+        let state_root = match crate::config::state_root_dir() {
+            Some(root) => root,
             None => {
-                msg_debug(&format!("[auto_workspace] chat_id={}, home_dir() returned None", chat_id.0));
+                msg_debug(&format!("[auto_workspace] chat_id={}, state_root_dir() returned None", chat_id.0));
                 return None;
             }
         };
-        let workspace_dir = home.join(".cokacdir").join("workspace");
+        let workspace_dir = state_root.join("workspace");
         use rand::Rng;
         let random_name: String = rand::thread_rng()
             .sample_iter(&rand::distributions::Alphanumeric)
@@ -2916,9 +2916,9 @@ fn capitalize_platform(name: &str) -> String {
     }
 }
 
-/// Path to bot settings file: ~/.cokacdir/bot_settings.json
+/// Path to bot settings file under the effective state root.
 fn bot_settings_path() -> Option<std::path::PathBuf> {
-    dirs::home_dir().map(|h| h.join(".cokacdir").join("bot_settings.json"))
+    crate::config::state_root_dir().map(|root| root.join("bot_settings.json"))
 }
 
 /// Load bot settings from bot_settings.json
@@ -3264,9 +3264,9 @@ pub fn resolve_display_name_by_username(username: &str) -> Option<String> {
     None
 }
 
-/// Directory for bot-to-bot message files: ~/.cokacdir/messages/
+/// Directory for bot-to-bot message files under the effective state root.
 pub fn messages_dir() -> Option<std::path::PathBuf> {
-    let result = dirs::home_dir().map(|h| h.join(".cokacdir").join("messages"));
+    let result = crate::config::state_root_dir().map(|root| root.join("messages"));
     msg_debug(&format!("[messages_dir] result={:?}", result));
     result
 }
@@ -5623,13 +5623,13 @@ async fn handle_start_command(
     let mut is_path_intent = false;
     let canonical_path = if path_str.is_empty() {
         // Create random workspace directory
-        let Some(home) = dirs::home_dir() else {
+        let Some(state_root) = crate::config::state_root_dir() else {
             shared_rate_limit_wait(state, chat_id).await;
-            tg!("send_message", bot.send_message(chat_id, "Error: cannot determine home directory.")
+            tg!("send_message", bot.send_message(chat_id, "Error: cannot determine state root.")
                 .await)?;
             return Ok(());
         };
-        let workspace_dir = home.join(".cokacdir").join("workspace");
+        let workspace_dir = state_root.join("workspace");
         use rand::Rng;
         let random_name: String = rand::thread_rng()
             .sample_iter(&rand::distributions::Alphanumeric)
@@ -5927,8 +5927,8 @@ async fn handle_start_command(
             response_lines.push(format!("[{}] Session restored at `{}`.", provider_str, canonical_path));
             if let Some(folder_name) = std::path::Path::new(&canonical_path).file_name().and_then(|n| n.to_str()) {
                 if is_workspace_id(folder_name)
-                    && dirs::home_dir()
-                        .map(|h| h.join(".cokacdir").join("workspace").join(folder_name).is_dir())
+                    && crate::config::state_root_dir()
+                        .map(|root| root.join("workspace").join(folder_name).is_dir())
                         .unwrap_or(false)
                 {
                     response_lines.push(format!("Use /{} to resume this session.", folder_name));
@@ -5953,8 +5953,8 @@ async fn handle_start_command(
             // Show workspace ID shortcut if this is a workspace directory
             if let Some(folder_name) = std::path::Path::new(&canonical_path).file_name().and_then(|n| n.to_str()) {
                 if is_workspace_id(folder_name)
-                    && dirs::home_dir()
-                        .map(|h| h.join(".cokacdir").join("workspace").join(folder_name).is_dir())
+                    && crate::config::state_root_dir()
+                        .map(|root| root.join("workspace").join(folder_name).is_dir())
                         .unwrap_or(false)
                 {
                     response_lines.push(format!("Use /{} to resume this session.", folder_name));
@@ -6916,14 +6916,14 @@ async fn handle_workspace_resume(
     token: &str,
 ) -> ResponseResult<()> {
     msg_debug(&format!("[workspace_resume] chat_id={}, workspace_id={}", chat_id.0, workspace_id));
-    let Some(home) = dirs::home_dir() else {
+    let Some(state_root) = crate::config::state_root_dir() else {
         shared_rate_limit_wait(state, chat_id).await;
-        tg!("send_message", bot.send_message(chat_id, "Error: cannot determine home directory.")
+        tg!("send_message", bot.send_message(chat_id, "Error: cannot determine state root.")
             .await)?;
         return Ok(());
     };
 
-    let workspace_path = home.join(".cokacdir").join("workspace").join(workspace_id);
+    let workspace_path = state_root.join("workspace").join(workspace_id);
     if !workspace_path.exists() || !workspace_path.is_dir() {
         shared_rate_limit_wait(state, chat_id).await;
         tg!("send_message", bot.send_message(chat_id, format!("Error: no workspace found for '{}'.", workspace_id))
@@ -8096,8 +8096,8 @@ async fn handle_shell_command(
                                 .parse_mode(ParseMode::Html).await);
 
                             let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
-                            if let Some(home) = dirs::home_dir() {
-                                let tmp_dir = home.join(".cokacdir").join("tmp");
+                            if let Some(state_root) = crate::config::state_root_dir() {
+                                let tmp_dir = state_root.join("tmp");
                                 let _ = std::fs::create_dir_all(&tmp_dir);
                                 let tmp_path = tmp_dir
                                     .join(format!("cokacdir_shell_{}_{}.txt", chat_id.0, timestamp))
@@ -10882,12 +10882,12 @@ fn floor_char_boundary(s: &str, index: usize) -> usize {
 }
 
 /// Process one pending upload queue file for the given chat.
-/// Scans ~/.cokacdir/upload_queue/ for .queue files matching the current bot and chat_id,
+/// Scans state-root upload_queue/ for .queue files matching the current bot and chat_id,
 /// sends the oldest one, and deletes the queue file on success.
 /// Returns true if a file was processed (rate limit slot consumed).
 async fn process_upload_queue(bot: &Bot, chat_id: ChatId, state: &SharedState) -> bool {
-    let queue_dir = match dirs::home_dir() {
-        Some(h) => h.join(".cokacdir").join("upload_queue"),
+    let queue_dir = match crate::config::state_root_dir() {
+        Some(root) => root.join("upload_queue"),
         None => return false,
     };
     if !queue_dir.is_dir() {
@@ -11103,8 +11103,8 @@ async fn send_response_as_file(
     state: &SharedState,
     label: &str,
 ) -> bool {
-    let Some(home) = dirs::home_dir() else { return false };
-    let tmp_dir = home.join(".cokacdir").join("tmp");
+    let Some(state_root) = crate::config::state_root_dir() else { return false };
+    let tmp_dir = state_root.join("tmp");
     let _ = std::fs::create_dir_all(&tmp_dir);
     let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
     let tmp_path = tmp_dir.join(format!("cokacdir_{}_{}.txt", label, timestamp));
@@ -11897,9 +11897,9 @@ async fn execute_schedule(
     println!("  [{ts}] ⏰ Schedule Starting: {user_prompt}");
 
     // Create persistent workspace directory for this schedule execution
-    let Some(home) = dirs::home_dir() else {
+    let Some(state_root) = crate::config::state_root_dir() else {
         let ts = chrono::Local::now().format("%H:%M:%S");
-        println!("  [{ts}] ⚠ [Schedule] Failed to get home directory");
+        println!("  [{ts}] ⚠ [Schedule] Failed to get state root");
         {
             let mut data = state.lock().await;
             if let Some(set) = data.pending_schedules.get_mut(&chat_id) {
@@ -11917,7 +11917,7 @@ async fn execute_schedule(
         process_next_queued_message(bot, chat_id, state).await;
         return;
     };
-    let workspace_dir = home.join(".cokacdir").join("workspace").join(&schedule_id);
+    let workspace_dir = state_root.join("workspace").join(&schedule_id);
     sched_debug(&format!("[execute_schedule] id={}, creating workspace: {}", schedule_id, workspace_dir.display()));
     if let Err(e) = fs::create_dir_all(&workspace_dir) {
         let ts = chrono::Local::now().format("%H:%M:%S");
@@ -13903,4 +13903,107 @@ async fn scheduler_cycle(
             msg_debug("[scheduler_loop] checking message timeouts");
             check_message_timeouts(&bot, &bot_username, &state).await;
         }
+}
+
+#[cfg(test)]
+mod state_root_leak_tests {
+    use super::{
+        bot_settings_path, group_chat_log_dir, load_cowork_guidelines, messages_dir,
+        save_payload_value, schedule_dir, schedule_history_path_pub,
+    };
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn with_home_and_state_root<T>(f: impl FnOnce(PathBuf, PathBuf) -> T) -> T {
+        let home = tempdir().unwrap();
+        let state_root = tempdir().unwrap();
+        let previous_home = std::env::var_os("HOME");
+        let previous_state_root = std::env::var_os("COKACDIR_STATE_ROOT");
+        std::env::set_var("HOME", home.path());
+        std::env::set_var("COKACDIR_STATE_ROOT", state_root.path());
+        let result = f(home.path().to_path_buf(), state_root.path().to_path_buf());
+        match previous_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+        match previous_state_root {
+            Some(value) => std::env::set_var("COKACDIR_STATE_ROOT", value),
+            None => std::env::remove_var("COKACDIR_STATE_ROOT"),
+        }
+        result
+    }
+
+    #[test]
+    fn save_payload_value_uses_state_root_override() {
+        with_home_and_state_root(|home, state_root| {
+            let saved = save_payload_value("payload content").expect("should save payload");
+            let saved_path = PathBuf::from(saved);
+            let expected_prefix = state_root.join("values");
+            assert!(
+                saved_path.starts_with(&expected_prefix),
+                "saved path should stay under state root: {}",
+                saved_path.display()
+            );
+            assert!(
+                !home.join(".cokacdir").join("values").exists(),
+                "home-root values dir should remain unused"
+            );
+        });
+    }
+
+    #[test]
+    fn group_chat_log_dir_uses_state_root_override() {
+        with_home_and_state_root(|_home, state_root| {
+            assert_eq!(
+                group_chat_log_dir(),
+                Some(state_root.join("group_chat"))
+            );
+        });
+    }
+
+    #[test]
+    fn bot_settings_path_uses_state_root_override() {
+        with_home_and_state_root(|_home, state_root| {
+            assert_eq!(
+                bot_settings_path(),
+                Some(state_root.join("bot_settings.json"))
+            );
+        });
+    }
+
+    #[test]
+    fn messages_dir_uses_state_root_override() {
+        with_home_and_state_root(|_home, state_root| {
+            assert_eq!(
+                messages_dir(),
+                Some(state_root.join("messages"))
+            );
+        });
+    }
+
+    #[test]
+    fn load_cowork_guidelines_reads_state_root_prompt() {
+        with_home_and_state_root(|home, state_root| {
+            let home_prompt_dir = home.join(".cokacdir").join("prompt");
+            let state_prompt_dir = state_root.join("prompt");
+            std::fs::create_dir_all(&home_prompt_dir).unwrap();
+            std::fs::create_dir_all(&state_prompt_dir).unwrap();
+            std::fs::write(home_prompt_dir.join("cowork.md"), "from-home").unwrap();
+            std::fs::write(state_prompt_dir.join("cowork.md"), "from-state-root").unwrap();
+
+            let loaded = load_cowork_guidelines();
+            assert_eq!(loaded, "from-state-root");
+        });
+    }
+
+    #[test]
+    fn schedule_dirs_use_state_root_override() {
+        with_home_and_state_root(|_home, state_root| {
+            assert_eq!(schedule_dir(), Some(state_root.join("schedule")));
+            assert_eq!(
+                schedule_history_path_pub("ABCDEF12"),
+                Some(state_root.join("schedule_history").join("ABCDEF12.log"))
+            );
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- route remaining `cokacdir` stateful Telegram/runtime paths through the configured state-root instead of hard-coded home paths
- move schedule and schedule-history handling onto the state-rooted path family
- ensure schedule result writes create their target directory before emitting `.result` files
- keep the macOS sensitive-target regression green while finishing the state-root wave

## Files
- `src/config.rs`
- `src/main.rs`
- `src/services/telegram.rs`
- `src/services/file_ops.rs`

## Verification
- `cargo build`
- `cargo test test_state_root_dir_prefers_env_override -- --test-threads=1`
- `cargo test test_ensure_config_exists_uses_env_override -- --test-threads=1`
- `cargo test state_root_leak_tests -- --test-threads=1`
- `cargo test test_target_is_sensitive_private_prefix -- --test-threads=1`
- isolated CLI smoke for `--currenttime`, `--sendfile`, and `--cron register/list/remove` under `COKACDIR_STATE_ROOT=<tmp>`

## Notes
- this was verified in isolated checkouts only; no live rollout, service restart, or real `~/.cokacdir` mutation was performed during prep