### PR TITLE
feat(telegram): render Markdown tables as native Rich Messages (opt-in)

### DIFF
--- a/src/services/telegram.rs
+++ b/src/services/telegram.rs
@@ -960,6 +960,9 @@ struct BotSettings {
     /// chat_id (string) -> transcriptor model setting for STT.
     /// Bare values are passed as `--model-name`; `path:<PATH>` is passed as `--model`.
     stt_models: HashMap<String, String>,
+    /// chat_id (string) -> true if responses containing a Markdown table should
+    /// be rendered as native Telegram Rich Messages (Bot API 10.1). Opt-in.
+    rich_messages: HashMap<String, bool>,
 }
 
 impl Default for BotSettings {
@@ -985,6 +988,7 @@ impl Default for BotSettings {
             codex_fast: HashMap::new(),
             claude_effort: HashMap::new(),
             stt_models: HashMap::new(),
+            rich_messages: HashMap::new(),
         }
     }
 }
@@ -1056,6 +1060,23 @@ fn is_codex_fast(settings: &BotSettings, chat_id: ChatId) -> bool {
         .get(&chat_id.0.to_string())
         .copied()
         .unwrap_or(false)
+}
+
+/// True if this chat has opted in to native Telegram table rendering
+/// (Bot API 10.1 Rich Messages). Defaults to false.
+fn is_rich_messages_enabled(settings: &BotSettings, chat_id: ChatId) -> bool {
+    settings
+        .rich_messages
+        .get(&chat_id.0.to_string())
+        .copied()
+        .unwrap_or(false)
+}
+
+/// Async convenience wrapper that locks shared state to read the per-chat
+/// `rich_messages` opt-in flag.
+async fn rich_messages_on(state: &SharedState, chat_id: ChatId) -> bool {
+    let data = state.lock().await;
+    is_rich_messages_enabled(&data.settings, chat_id)
 }
 
 fn get_stt_model(settings: &BotSettings, chat_id: ChatId) -> Option<String> {
@@ -2886,6 +2907,7 @@ fn build_system_prompt(
     user_message: Option<&str>,
     context_count: usize,
     platform: &str,
+    rich_messages_enabled: bool,
 ) -> String {
     msg_debug(&format!("[build_system_prompt] chat_id={}, bot_username={:?}, bot_display_name={:?}, session_id={:?}, disabled_notice_len={}, role_len={}",
         chat_id, bot_username, bot_display_name, session_id, disabled_notice.len(), role.len()));
@@ -3152,6 +3174,11 @@ fn build_system_prompt(
     } else {
         String::new()
     };
+    let table_instruction = if rich_messages_enabled {
+        "Markdown tables are supported and render as native Telegram tables."
+    } else {
+        "Do NOT use Markdown tables."
+    };
     format!(
         "{role}\n\
          {bot_username_line}\
@@ -3163,7 +3190,7 @@ fn build_system_prompt(
          IMPORTANT: The user is on {platform} and CANNOT interact with any interactive prompts, dialogs, or confirmation requests. \
          All tools that require user interaction (such as AskUserQuestion, EnterPlanMode, ExitPlanMode) will NOT work. \
          Never use tools that expect user interaction. If you need clarification, just ask in plain text.\n\n\
-         Response format: Use Markdown by default, but do NOT use Markdown tables.\n\n\
+         Response format: Use Markdown by default. {table_instruction}\n\n\
          If the user asks about how to use cokacdir, refer to the documentation files in ~/.cokacdir/docs/ for accurate guidance.\n\n\
          ═══════════════════════════════════════\n\
          COKACDIR COMMAND REFERENCE\n\
@@ -3974,6 +4001,16 @@ fn load_bot_settings(token: &str) -> BotSettings {
         })
         .unwrap_or_default();
 
+    let rich_messages: HashMap<String, bool> = entry
+        .get("rich_messages")
+        .and_then(|v| v.as_object())
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_bool().map(|b| (k.clone(), b)))
+                .collect()
+        })
+        .unwrap_or_default();
+
     BotSettings {
         allowed_tools,
         last_sessions,
@@ -3995,6 +4032,7 @@ fn load_bot_settings(token: &str) -> BotSettings {
         codex_fast,
         claude_effort,
         stt_models,
+        rich_messages,
     }
 }
 
@@ -4054,6 +4092,7 @@ fn save_bot_settings(token: &str, settings: &BotSettings) {
         "codex_fast": settings.codex_fast,
         "claude_effort": settings.claude_effort,
         "stt_models": settings.stt_models,
+        "rich_messages": settings.rich_messages,
     });
     if let Some(owner_id) = settings.owner_user_id {
         entry["owner_user_id"] = serde_json::json!(owner_id);
@@ -4299,6 +4338,7 @@ fn is_owner_only_command(text: &str) -> bool {
             | "stt_model"
             | "effort"
             | "fast"
+            | "richmessages"
             | "greeting"
             | "debug"
             | "envvars"
@@ -5056,6 +5096,7 @@ pub async fn run_bot(token: &str, api_url: Option<&str>) -> BotExit {
         teloxide::types::BotCommand::new("stt_model", "Set speech recognition model"),
         teloxide::types::BotCommand::new("effort", "Set Claude/Codex effort level"),
         teloxide::types::BotCommand::new("fast", "Toggle Codex fast service tier"),
+        teloxide::types::BotCommand::new("richmessages", "Toggle native Markdown table rendering"),
         teloxide::types::BotCommand::new("debug", "Toggle debug logging"),
         teloxide::types::BotCommand::new("envvars", "Show all environment variables"),
         teloxide::types::BotCommand::new("silent", "Toggle silent mode (hide tool calls)"),
@@ -9203,6 +9244,13 @@ async fn handle_message(
             command_args(&text)
         );
         handle_fast_command(&bot, chat_id, &text, &state, token).await?;
+    } else if is_cmd(&text, "richmessages") {
+        msg_debug("[handle_message] routing → /richmessages");
+        println!(
+            "  [{timestamp}] ◀ [{user_name}] /richmessages {}",
+            command_args(&text)
+        );
+        handle_richmessages_command(&bot, chat_id, &text, &state, token).await?;
     } else if is_cmd(&text, "greeting") {
         msg_debug("[handle_message] routing → /greeting");
         println!("  [{timestamp}] ◀ [{user_name}] /greeting");
@@ -9506,6 +9554,7 @@ Ask in natural language to manage schedules.
 <code>/effort</code> — Show current Claude/Codex effort
 <code>/effort &lt;level&gt;</code> — Set effort (Claude: low/medium/high/xhigh/max, Codex: minimal/low/medium/high/xhigh, or reset)
 <code>/fast</code> — Toggle Codex fast service tier
+<code>/richmessages</code> — Toggle native Markdown table rendering
 <code>/setpollingtime &lt;ms&gt;</code> — Set API polling interval
   Too low may cause API rate limits.
   Minimum 2500ms, recommended 3000ms+.
@@ -14474,6 +14523,73 @@ async fn handle_fast_command(
     Ok(())
 }
 
+/// Handle /richmessages command — toggle native Telegram table rendering
+/// (Bot API 10.1 Rich Messages) for the current chat.
+async fn handle_richmessages_command(
+    bot: &Bot,
+    chat_id: ChatId,
+    text: &str,
+    state: &SharedState,
+    token: &str,
+) -> ResponseResult<()> {
+    let arg = command_args(text).trim().to_lowercase();
+
+    if arg == "status" || arg == "show" {
+        let enabled = rich_messages_on(state, chat_id).await;
+        let status = if enabled {
+            "📊 Rich tables: ON (Markdown tables render natively)"
+        } else {
+            "📊 Rich tables: OFF (Markdown tables shown as plain text)"
+        };
+        shared_rate_limit_wait(state, chat_id).await;
+        tg!("send_message", bot.send_message(chat_id, status).await)?;
+        return Ok(());
+    }
+
+    let requested = match arg.as_str() {
+        "" => None,
+        "on" | "enable" | "enabled" | "true" | "1" => Some(true),
+        "off" | "disable" | "disabled" | "false" | "0" | "reset" | "clear" | "default" => {
+            Some(false)
+        }
+        _ => {
+            shared_rate_limit_wait(state, chat_id).await;
+            tg!(
+                "send_message",
+                bot.send_message(
+                    chat_id,
+                    "Usage: /richmessages, /richmessages on, /richmessages off, /richmessages status",
+                )
+                .await
+            )?;
+            return Ok(());
+        }
+    };
+
+    let next = {
+        let mut data = state.lock().await;
+        let key = chat_id.0.to_string();
+        let prev = is_rich_messages_enabled(&data.settings, chat_id);
+        let next = requested.unwrap_or(!prev);
+        if next {
+            data.settings.rich_messages.insert(key, true);
+        } else {
+            data.settings.rich_messages.remove(&key);
+        }
+        save_bot_settings(token, &data.settings);
+        next
+    };
+
+    let status = if next {
+        "📊 Rich tables: ON (Markdown tables render natively)"
+    } else {
+        "📊 Rich tables: OFF (Markdown tables shown as plain text)"
+    };
+    shared_rate_limit_wait(state, chat_id).await;
+    tg!("send_message", bot.send_message(chat_id, status).await)?;
+    Ok(())
+}
+
 /// Handle /stt_model command - set or view transcriptor model for this chat.
 async fn handle_stt_model_command(
     bot: &Bot,
@@ -15537,6 +15653,7 @@ async fn handle_text_message(
         role.len(),
         current_path
     ));
+    let rich_messages_enabled = rich_messages_on(&state, chat_id).await;
     let system_prompt_owned = build_system_prompt(
         &role,
         &current_path,
@@ -15549,6 +15666,7 @@ async fn handle_text_message(
         Some(user_text),
         context_count,
         &platform,
+        rich_messages_enabled,
     );
 
     // Create channel for streaming
@@ -16285,6 +16403,19 @@ async fn handle_text_message(
                         "response",
                     )
                     .await;
+                } else if last_confirmed_len == 0
+                    && contains_markdown_table(&final_response)
+                    && rich_messages_on(&state_owned, chat_id).await
+                    && finalize_as_rich_table(
+                        &bot_owned,
+                        chat_id,
+                        placeholder_msg_id,
+                        &final_response,
+                        &state_owned,
+                    )
+                    .await
+                {
+                    msg_debug("[rolling_ph] FINAL sent as Rich Message (table)");
                 } else {
                     let normalized_remaining = normalize_empty_lines(remaining);
                     let html_remaining = markdown_to_telegram_html(&normalized_remaining);
@@ -17674,6 +17805,113 @@ async fn send_long_message(
     Ok(())
 }
 
+/// True if `md` contains a GitHub-flavored Markdown table: a header row
+/// immediately followed by a separator row such as `|---|---|`. Lines inside
+/// fenced code blocks are skipped so pipes in code do not trigger a false match.
+fn contains_markdown_table(md: &str) -> bool {
+    let mut in_fence = false;
+    let mut prev_has_pipe = false;
+    for line in md.lines() {
+        let t = line.trim();
+        if t.starts_with("```") {
+            in_fence = !in_fence;
+            prev_has_pipe = false;
+            continue;
+        }
+        if in_fence {
+            prev_has_pipe = false;
+            continue;
+        }
+        let is_separator = !t.is_empty()
+            && t.contains('|')
+            && t.contains('-')
+            && t.chars().all(|c| matches!(c, '|' | '-' | ':' | ' '));
+        if is_separator && prev_has_pipe {
+            return true;
+        }
+        prev_has_pipe = t.contains('|');
+    }
+    false
+}
+
+/// Send `markdown` as a Telegram Rich Message via the Bot API 10.1
+/// `sendRichMessage` method (which renders tables, headings, lists, etc.
+/// natively). teloxide 0.13 does not yet wrap this method, so the request is
+/// issued directly with reqwest. Returns `Ok(())` only when Telegram answers
+/// `ok: true`.
+async fn send_rich_markdown(
+    bot: &Bot,
+    chat_id: ChatId,
+    markdown: &str,
+    state: &SharedState,
+) -> Result<(), String> {
+    let base = {
+        let data = state.lock().await;
+        data.api_base_url.clone()
+    };
+    let token = bot.token().to_string();
+    let url = format!("{}/bot{}/sendRichMessage", base, token);
+    let scrub = |s: String| s.replace(&token, "<bot_token_redacted>");
+    let body = serde_json::json!({
+        "chat_id": chat_id.0,
+        "rich_message": { "markdown": markdown },
+    });
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| scrub(format!("client build failed: {e}")))?;
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| scrub(format!("request failed: {e}")))?;
+    let status = resp.status();
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| scrub(format!("invalid JSON response: {e}")))?;
+    if json.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
+        Ok(())
+    } else {
+        let desc = json
+            .get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown error");
+        Err(format!("sendRichMessage failed (HTTP {status}): {desc}"))
+    }
+}
+
+/// Finalize a streamed response that contains a Markdown table by replacing the
+/// rolling placeholder with a Telegram Rich Message. On success the placeholder
+/// is deleted and `true` is returned; on any failure `false` is returned so the
+/// caller transparently falls back to the existing HTML rendering path.
+async fn finalize_as_rich_table(
+    bot: &Bot,
+    chat_id: ChatId,
+    placeholder_msg_id: teloxide::types::MessageId,
+    markdown: &str,
+    state: &SharedState,
+) -> bool {
+    shared_rate_limit_wait(state, chat_id).await;
+    match send_rich_markdown(bot, chat_id, markdown, state).await {
+        Ok(()) => {
+            shared_rate_limit_wait(state, chat_id).await;
+            let _ = tg!(
+                "delete_message",
+                bot.delete_message(chat_id, placeholder_msg_id).await
+            );
+            true
+        }
+        Err(e) => {
+            msg_debug(&format!(
+                "[rich_table] sendRichMessage failed, falling back to HTML: {e}"
+            ));
+            false
+        }
+    }
+}
+
 /// Send a large AI response as a .txt file attachment.
 /// Returns true if the file was successfully sent.
 async fn send_response_as_file(
@@ -18858,6 +19096,7 @@ async fn execute_schedule(
             None => base,
         }
     };
+    let rich_messages_enabled = rich_messages_on(&state, chat_id).await;
     let system_prompt_owned = build_system_prompt(
         &sched_role,
         &crate::utils::format::to_shell_path(&workspace_path),
@@ -18870,6 +19109,7 @@ async fn execute_schedule(
         None, // scheduled tasks: no user message dedup
         sched_context_count,
         &platform,
+        rich_messages_enabled,
     );
 
     // Retrieve pre-inserted cancel token (from scheduler_loop), or create a new one
@@ -19547,6 +19787,21 @@ async fn execute_schedule(
                     format!("{}{}", normalize_empty_lines(&full_response), continue_hint);
                 send_response_as_file(&bot_owned, chat_id, &final_text, &state_owned, "schedule")
                     .await;
+            } else if last_confirmed_len == 0 && {
+                let rich_md =
+                    format!("{}{}", normalize_empty_lines(&full_response), continue_hint);
+                contains_markdown_table(&rich_md)
+                    && rich_messages_on(&state_owned, chat_id).await
+                    && finalize_as_rich_table(
+                        &bot_owned,
+                        chat_id,
+                        placeholder_msg_id,
+                        &rich_md,
+                        &state_owned,
+                    )
+                    .await
+            } {
+                msg_debug("[rolling_ph/sched] FINAL sent as Rich Message (table)");
             } else {
                 let normalized_remaining = normalize_empty_lines(remaining);
                 let final_text = format!("{}{}", normalized_remaining, continue_hint);
@@ -20241,6 +20496,7 @@ async fn process_bot_message(
             format!("You are chatting with a user through {}.", platform)
         }
     };
+    let rich_messages_enabled = rich_messages_on(&state, chat_id).await;
     let system_prompt_owned = build_system_prompt(
         &role,
         &current_path,
@@ -20253,6 +20509,7 @@ async fn process_bot_message(
         None, // bot-to-bot messages: no user message dedup
         context_count,
         &platform,
+        rich_messages_enabled,
     );
     msg_debug(&format!(
         "[process_bot_message] system_prompt built, len={}",
@@ -20922,6 +21179,19 @@ async fn process_bot_message(
                         "botmsg",
                     )
                     .await;
+                } else if last_confirmed_len == 0
+                    && contains_markdown_table(&final_response)
+                    && rich_messages_on(&state_owned, chat_id).await
+                    && finalize_as_rich_table(
+                        &bot_owned,
+                        chat_id,
+                        placeholder_msg_id,
+                        &final_response,
+                        &state_owned,
+                    )
+                    .await
+                {
+                    msg_debug("[rolling_ph/botmsg] FINAL sent as Rich Message (table)");
                 } else {
                     let normalized_remaining = normalize_empty_lines(remaining);
                     let html_remaining = markdown_to_telegram_html(&normalized_remaining);


### PR DESCRIPTION
## 요약

Telegram이 2026-06-11 Bot API 10.1에서 도입한 [Rich Messages](https://core.telegram.org/bots/api#sendrichmessage)(`sendRichMessage`)를 사용해, **마크다운 표를 네이티브 표로 렌더링**합니다.

현재는 모든 응답이 `markdown_to_telegram_html()` → 구식 `sendMessage`(HTML)로 나가는데, 이 변환에는 표 처리가 없어 표가 파이프(`|`) 텍스트로 노출됩니다(시스템 프롬프트도 이 때문에 표를 금지). 신규 API라 리스크를 고려해 **per-chat opt-in(기본 OFF)** 으로 설계했습니다.

## 데모

`/richmessages on` 전후 비교 — 위: OFF(파이프 텍스트), 아래: ON(네이티브 표):

<!-- ↓ 이 줄 아래에 데모 스크린샷을 드래그&드롭하세요 -->
<img width="1280" height="1258" alt="screenshot_demo" src="https://github.com/user-attachments/assets/9a954c67-c029-418a-a259-9cf604f74b97" />

## 변경 사항

`src/services/telegram.rs` 한 파일, +271/-1. **기존 로직 수정 없이 순수 추가 + 분기.**

**헬퍼 3개**
- `contains_markdown_table()` — GFM 표(헤더행 + `|---|` 구분행) 감지. 코드펜스 내부 제외로 오탐 방지.
- `send_rich_markdown()` — teloxide 0.13에 없는 `sendRichMessage`를 reqwest로 직접 호출. `api_base_url`(프록시) 존중, 토큰 리댁션, 30s 타임아웃, `ok:true`만 성공 처리.
- `finalize_as_rich_table()` — 롤링 placeholder를 삭제 후 Rich Message로 교체. 실패 시 기존 HTML 경로로 폴백.

**설정 · 명령어**
- `BotSettings.rich_messages: HashMap<String, bool>` (기본 OFF) + `bot_settings.json` 영속화.
- `/richmessages` (`on`/`off`/`status`/토글) — 기존 `/fast` 패턴과 동일. BotCommand·라우팅·`/help` 포함.

**연동**
- 스트리밍 최종 전송 3경로(`handle_text_message`·`execute_schedule`·`process_bot_message`)에 분기 추가: **표 포함 + 단일 메시지(`last_confirmed_len == 0`) + opt-in ON**일 때만 Rich 전송.
- 시스템 프롬프트가 설정에 연동되어, ON일 때만 AI에게 표 사용을 허용.

## 설계 원칙

- **최소 침습 / 회귀 0** — 기존 `} else {` 앞에 `} else if {…}`만 삽입. 그 외 트래픽은 모두 기존 경로 유지.
- **항상 폴백** — 신규 API 실패 시 자동으로 기존 HTML 경로로 복귀.
- **Flood 회피** — 스트리밍 델타는 기존 HTML edit 유지(델타마다 Rich 재전송 회피, #30 관련). 표는 최종 확정 시점에만 렌더.

## 알려진 범위 (1차)

- 단일 메시지로 끝나는 응답의 표만 Rich 처리. 4096자 초과로 분할되는 응답은 기존 경로 유지(표는 텍스트). 후속 확장 가능.
- 스트리밍 중에는 표가 텍스트로 보이다가 완료 시 Rich 표로 교체.

## 테스트

- `cargo build` 통과, 신규 경고 0.
- 실제 봇 검증:
  - OFF(기본): 표 요청 → 파이프 텍스트(기존 동작 유지) ✅
  - `/richmessages on` → 설정 저장 확인 ✅ / ON: 표 요청 → 네이티브 표 ✅
  - 코드블록 내 `|` → 표로 오탐 안 됨 ✅
  - 표 없는 일반 응답 → 회귀 없음 ✅


<img width="727" height="1644" alt="SCR-20260617-jtbc" src="https://github.com/user-attachments/assets/4a11c2cc-e474-4cd4-908a-2ae774915cc7" />
