### PR TITLE
feat: Herdr 에이전트 제공자 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,14 @@ For AI provider setup, keyboard shortcuts, and detailed documentation, visit:
 
 For the measured Antigravity CLI integration contract, see [How cokacdir Uses Antigravity CLI (`agy`)](docs/how-to-use-agy-antigravity.md).
 
+To route bot requests to an already-running named Herdr agent, see
+[How to Use Herdr Agents](docs/how-to-use-herdr.md).
+
 ## Chat Bots
 
 **Features:**
 
-* Multi-provider support (Claude, Codex, Agy, OpenCode) with real-time streaming
+* Multi-provider support (Claude, Codex, Agy, OpenCode, Herdr) with native streaming where supported
 * Session persistence and cross-provider session interpretation
 * Scheduled tasks using cron expressions or absolute time
 * Request queue and cancellation controls (`/queue`, `/stop`, `/stopall`, `/stop_<id>`)
@@ -78,7 +81,7 @@ For the measured Antigravity CLI integration contract, see [How cokacdir Uses An
 
 ## Configuration
 
-cokacdir reads environment variables at startup to override binary paths (`COKAC_CLAUDE_PATH`, `COKAC_CODEX_PATH`, `COKAC_AGY_PATH`, `COKAC_OPENCODE_PATH`), tune the file-attachment threshold (`COKAC_FILE_ATTACH_THRESHOLD`), switch schedules into inline chat-session mode (`COKAC_SCHEDULE_INLINE=1`), and enable debug logging (`COKACDIR_DEBUG=1`). Variables can be set either in your shell environment or in a JSON file at `~/.cokacdir/.env.json` (values in that file take priority). Use the `/envvars` chat command (bot-owner only, 1:1 chat only) to inspect which values are active in the running process. See the [Environment Variables guide](https://cokacdir.cokac.com/#/docs/env-vars) for the full reference.
+cokacdir reads environment variables at startup to override binary paths (`COKAC_CLAUDE_PATH`, `COKAC_CODEX_PATH`, `COKAC_AGY_PATH`, `COKAC_OPENCODE_PATH`, `COKAC_HERDR_PATH`), tune the file-attachment threshold (`COKAC_FILE_ATTACH_THRESHOLD`), switch schedules into inline chat-session mode (`COKAC_SCHEDULE_INLINE=1`), and enable debug logging (`COKACDIR_DEBUG=1`). Variables can be set either in your shell environment or in a JSON file at `~/.cokacdir/.env.json` (values in that file take priority). Use the `/envvars` chat command (bot-owner only, 1:1 chat only) to inspect which values are active in the running process. See the [Environment Variables guide](https://cokacdir.cokac.com/#/docs/env-vars) for the full reference.
 
 The file-manager Settings dialog includes **Cross-volume move** verification.
 The default `Standard` mode keeps private staging, source identity checks,

--- a/docs/how-to-configure-environment-variables.md
+++ b/docs/how-to-configure-environment-variables.md
@@ -79,6 +79,43 @@ Override the path to the Opencode CLI binary. Same semantics as above but for Op
 - **Default:** not set (automatic resolution)
 - **Example:** `COKAC_OPENCODE_PATH=/usr/local/bin/opencode`
 
+### `COKAC_HERDR_PATH`
+
+Override the path to the [Herdr](https://github.com/ogulcancelik/herdr) CLI
+binary. Cokacdir uses Herdr to submit prompts to an already-running named agent,
+wait for it to settle, and read its terminal response.
+
+- **Type:** absolute path to an existing executable
+- **Default:** not set (`herdr` is resolved from `PATH`)
+- **Example:** `COKAC_HERDR_PATH=/usr/local/bin/herdr`
+
+### `COKAC_HERDR_AGENT`
+
+Set the default Herdr agent name used by `/model herdr`. You can select another
+running agent explicitly with `/model herdr:<agent-name>`.
+
+- **Type:** 1-32 lowercase letters, digits, `-`, or `_`; the first character must be a letter
+- **Default:** not set
+- **Example:** `COKAC_HERDR_AGENT=worker`
+
+### `COKAC_HERDR_TIMEOUT_MS`
+
+Set how long Cokacdir waits for a prompted Herdr agent to reach `idle`, `done`,
+or `blocked`.
+
+- **Type:** integer milliseconds, minimum `1000`
+- **Default:** `1800000` (30 minutes)
+- **Example:** `COKAC_HERDR_TIMEOUT_MS=600000`
+
+### `COKAC_HERDR_READ_LINES`
+
+Set the maximum number of recent unwrapped terminal lines Cokacdir reads before
+and after a Herdr turn to extract the response.
+
+- **Type:** positive integer
+- **Default:** `1000`
+- **Example:** `COKAC_HERDR_READ_LINES=500`
+
 ### `COKAC_FILE_ATTACH_THRESHOLD`
 
 Controls the size threshold (in bytes) at which the bot switches from sending a response as multiple Telegram messages to sending it as a single `.txt` file attachment.

--- a/docs/how-to-configure-settings.md
+++ b/docs/how-to-configure-settings.md
@@ -236,7 +236,7 @@ Useful for verifying that `~/.cokacdir/.env.json` loaded correctly, or checking 
 
 > ⚠ **Security warning:** `/envvars` exposes **all** environment variables with no redaction — including API keys, tokens, and credentials. Telegram stores message history on its servers, so anything printed by this command is persisted until you delete the messages. Use it only for diagnostics, clear the response afterward, and **always use it in a 1:1 chat**. Group chats are rejected for this command.
 
-See [How to Configure Environment Variables](how-to-configure-environment-variables.md) for the full list of variables cokacdir reads (`COKAC_CLAUDE_PATH`, `COKAC_CODEX_PATH`, `COKAC_AGY_PATH`, `COKAC_OPENCODE_PATH`, `COKAC_FILE_ATTACH_THRESHOLD`, `COKACDIR_DEBUG`) and for the `~/.cokacdir/.env.json` auto-loader.
+See [How to Configure Environment Variables](how-to-configure-environment-variables.md) for the full list of variables cokacdir reads (`COKAC_CLAUDE_PATH`, `COKAC_CODEX_PATH`, `COKAC_AGY_PATH`, `COKAC_OPENCODE_PATH`, `COKAC_HERDR_PATH`, `COKAC_FILE_ATTACH_THRESHOLD`, `COKACDIR_DEBUG`) and for the `~/.cokacdir/.env.json` auto-loader.
 
 ---
 

--- a/docs/how-to-use-herdr.md
+++ b/docs/how-to-use-herdr.md
@@ -1,0 +1,67 @@
+# How to Use Herdr Agents
+
+Cokacdir can route bot requests to an already-running
+[Herdr](https://github.com/ogulcancelik/herdr) agent. This lets a Telegram,
+Discord, or Slack bot continue an interactive agent session that is visible in
+a Herdr pane.
+
+## Prerequisites
+
+1. Install the `herdr` CLI and start its server.
+2. Start or name an agent in a Herdr pane.
+3. Confirm that the same user and environment that runs Cokacdir can resolve
+   the agent:
+
+   ```bash
+   herdr agent get worker
+   ```
+
+Cokacdir does not create or resume Herdr agents. The target must already be
+running and ready to accept interactive input.
+
+## Configuration
+
+Select a target directly from chat:
+
+```text
+/model herdr:worker
+```
+
+To make `/model herdr` use a default target, add the following to
+`~/.cokacdir/.env.json`:
+
+```json
+{
+  "COKAC_HERDR_PATH": "/usr/local/bin/herdr",
+  "COKAC_HERDR_AGENT": "worker"
+}
+```
+
+Restart Cokacdir after changing the environment file. Herdr-specific
+environment such as `HERDR_SOCKET_PATH` is inherited by the CLI process.
+
+## Turn lifecycle
+
+For each request, Cokacdir:
+
+1. Reads the target agent's recent terminal output.
+2. Submits the user request with `herdr agent prompt ... --wait`.
+3. Waits for the agent to become `idle`, `done`, or `blocked`.
+4. Reads the terminal again and returns the current turn's final response.
+
+Cokacdir forwards the current request without prepending its generated system
+prompt. The existing agent session keeps its own system, project, and
+conversation context.
+
+Codex TUI final responses are extracted from the current turn while tool output
+and UI chrome are omitted. Other agent terminal layouts fall back to the
+terminal delta and may include intermediate output.
+
+Use `/stop` to cancel the waiting Cokacdir request and send `Ctrl+C` to the
+target Herdr agent.
+
+## Security
+
+Herdr access grants interactive control over the target terminal session.
+Protect its socket and configuration directory, run Cokacdir as the intended
+user, and do not expose the socket to unrelated services.

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use crate::keybindings::PanelAction;
 use crate::services::agy;
 use crate::services::claude;
 use crate::services::codex;
+use crate::services::herdr;
 use crate::services::opencode;
 use crate::ui::app::{App, Screen};
 use crate::utils::markdown::{is_line_empty, render_markdown, MarkdownTheme};
@@ -1605,13 +1606,15 @@ fn handle_ccserver(tokens: Vec<String>) {
     let has_codex = codex::is_codex_available();
     let has_agy = agy::is_agy_available();
     let has_opencode = opencode::is_opencode_available();
+    let has_herdr = herdr::is_herdr_available();
     let mark = |available: bool| if available { "✓" } else { "✗" };
     println!(
-        "  ▸ Providers    : claude {}  codex {}  agy {}  opencode {}",
+        "  ▸ Providers    : claude {}  codex {}  agy {}  opencode {}  herdr {}",
         mark(has_claude),
         mark(has_codex),
         mark(has_agy),
-        mark(has_opencode)
+        mark(has_opencode),
+        mark(has_herdr)
     );
 
     if has_agy {
@@ -1619,10 +1622,10 @@ fn handle_ccserver(tokens: Vec<String>) {
         println!("  ▸ Agy          : v{}", ver);
     }
 
-    if !has_claude && !has_codex && !has_agy && !has_opencode {
+    if !has_claude && !has_codex && !has_agy && !has_opencode && !has_herdr {
         eprintln!();
         eprintln!("  Error: No AI provider available.");
-        eprintln!("  Install Claude CLI, Codex CLI, Antigravity CLI (agy), or OpenCode.");
+        eprintln!("  Install Claude CLI, Codex CLI, Antigravity CLI (agy), OpenCode, or Herdr.");
         std::process::exit(1);
     }
 

--- a/src/services/herdr.rs
+++ b/src/services/herdr.rs
@@ -170,6 +170,97 @@ fn is_tui_elapsed_time(line: &str) -> bool {
     line.starts_with('─') && line.contains("Worked for ") && line.ends_with('─')
 }
 
+fn is_ordered_list_item(line: &str) -> bool {
+    let digits = line.bytes().take_while(u8::is_ascii_digit).count();
+    digits > 0
+        && line
+            .get(digits..)
+            .is_some_and(|suffix| suffix.starts_with(". ") || suffix.starts_with(") "))
+}
+
+fn is_markdown_block_start(line: &str) -> bool {
+    let is_indented_code = line.starts_with('\t') || line.starts_with("    ");
+    let line = line.trim_start();
+    line.starts_with("```")
+        || line.starts_with("~~~")
+        || line.starts_with("# ")
+        || line.starts_with("## ")
+        || line.starts_with("### ")
+        || line.starts_with("#### ")
+        || line.starts_with("##### ")
+        || line.starts_with("###### ")
+        || line.starts_with("- ")
+        || line.starts_with("* ")
+        || line.starts_with("+ ")
+        || line.starts_with("• ")
+        || line.starts_with("> ")
+        || line.starts_with('|')
+        || is_indented_code
+        || is_ordered_list_item(line)
+}
+
+fn prevents_wrapped_continuation(line: &str) -> bool {
+    let is_indented_code = line.starts_with('\t') || line.starts_with("    ");
+    let line = line.trim_start();
+    line.starts_with('#')
+        || line.starts_with('>')
+        || line.starts_with('|')
+        || line.starts_with("```")
+        || line.starts_with("~~~")
+        || is_indented_code
+}
+
+fn unwrap_terminal_text(lines: impl IntoIterator<Item = String>) -> String {
+    let mut output: Vec<String> = Vec::new();
+    let mut in_code_fence = false;
+
+    for raw_line in lines {
+        let line = raw_line.trim_end();
+        let trimmed = line.trim();
+        let is_fence = trimmed.starts_with("```") || trimmed.starts_with("~~~");
+
+        if in_code_fence {
+            output.push(line.to_string());
+            if is_fence {
+                in_code_fence = false;
+            }
+            continue;
+        }
+
+        if trimmed.is_empty() {
+            if output.last().is_some_and(|line| !line.is_empty()) {
+                output.push(String::new());
+            }
+            continue;
+        }
+
+        if is_fence {
+            output.push(line.to_string());
+            in_code_fence = true;
+            continue;
+        }
+
+        let starts_block = is_markdown_block_start(line);
+        let can_join = !starts_block
+            && output.last().is_some_and(|previous| {
+                !previous.is_empty() && !prevents_wrapped_continuation(previous)
+            });
+
+        match (can_join, output.last_mut()) {
+            (true, Some(previous)) => {
+                previous.push(' ');
+                previous.push_str(trimmed);
+            }
+            _ => output.push(line.to_string()),
+        }
+    }
+
+    while output.last().is_some_and(String::is_empty) {
+        output.pop();
+    }
+    output.join("\n")
+}
+
 fn codex_final_response(turn_output: &str) -> Option<String> {
     let lines: Vec<&str> = turn_output.lines().collect();
     let input_index = lines
@@ -196,7 +287,7 @@ fn codex_final_response(turn_output: &str) -> Option<String> {
             .trim_end()
             .to_string()
     }));
-    let output = output.join("\n").trim().to_string();
+    let output = unwrap_terminal_text(output).trim().to_string();
     if output.is_empty() {
         None
     } else {
@@ -334,6 +425,67 @@ mod tests {
         assert_eq!(
             codex_final_response(snapshot).as_deref(),
             Some("Hello! How can I help?\n- First item\n- Second item")
+        );
+    }
+
+    #[test]
+    fn unwraps_terminal_wrapped_prose_and_preserves_lists() {
+        let snapshot = "\
+• Herdr integration can reliably\n\
+  support the following features.\n\
+\n\
+  - Stream progress commentary\n\
+  - Distinguish final responses\n\
+\n\
+  Bring the API draft back when it is\n\
+  ready for implementation.\n\
+\n\
+────────────────────────────────\n\
+\n\
+› Use /skills to list available skills";
+        assert_eq!(
+            codex_final_response(snapshot).as_deref(),
+            Some(
+                "Herdr integration can reliably support the following features.\n\
+\n\
+- Stream progress commentary\n\
+- Distinguish final responses\n\
+\n\
+Bring the API draft back when it is ready for implementation."
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_markdown_blocks_while_unwrapping_prose() {
+        let snapshot = "\
+• ## Windows\n\
+  Build with:\n\
+\n\
+  ```powershell\n\
+  cargo build --release\n\
+  $env:COKAC_HERDR_PATH = \"C:\\herdr.exe\"\n\
+  ```\n\
+\n\
+  Then restart the\n\
+  application.\n\
+\n\
+────────────────────────────────\n\
+\n\
+› Use /skills to list available skills";
+        assert_eq!(
+            codex_final_response(snapshot).as_deref(),
+            Some(
+                "## Windows\n\
+Build with:\n\
+\n\
+```powershell\n\
+cargo build --release\n\
+$env:COKAC_HERDR_PATH = \"C:\\herdr.exe\"\n\
+```\n\
+\n\
+Then restart the application."
+            )
         );
     }
 

--- a/src/services/herdr.rs
+++ b/src/services/herdr.rs
@@ -1,0 +1,383 @@
+//! Herdr agent provider.
+//!
+//! This adapter forwards a Cokacdir turn to an already-running Herdr agent,
+//! waits for the agent to settle, then reads the terminal output back.
+
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+use std::sync::atomic::Ordering;
+use std::sync::mpsc::Sender;
+
+use serde_json::Value;
+
+use crate::services::claude::{
+    attach_cancel_cgroup, detach_into_own_pgroup, enhanced_path_for_bin, kill_child_tree,
+    send_success_terminal, CancelToken, StreamMessage,
+};
+
+const DEFAULT_TIMEOUT_MS: u64 = 30 * 60 * 1000;
+const DEFAULT_READ_LINES: u32 = 1000;
+
+pub fn is_herdr_model(model: Option<&str>) -> bool {
+    model
+        .map(|model| model == "herdr" || model.starts_with("herdr:"))
+        .unwrap_or(false)
+}
+
+pub fn strip_herdr_prefix(model: &str) -> Option<&str> {
+    model
+        .strip_prefix("herdr:")
+        .filter(|target| !target.is_empty())
+}
+
+pub fn is_valid_target(target: &str) -> bool {
+    let mut chars = target.chars();
+    matches!(chars.next(), Some(first) if first.is_ascii_lowercase())
+        && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
+        && target.len() <= 32
+}
+
+pub fn target_from_model(model: Option<&str>) -> Result<String, String> {
+    if let Some(target) = model.and_then(strip_herdr_prefix) {
+        if is_valid_target(target) {
+            return Ok(target.to_string());
+        }
+        return Err(
+            "Invalid Herdr agent name. Use 1-32 lowercase letters, digits, '-' or '_'.".to_string(),
+        );
+    }
+
+    let target = std::env::var("COKAC_HERDR_AGENT").map_err(|_| {
+        "Herdr agent is not configured. Use /model herdr:<agent-name> or set COKAC_HERDR_AGENT."
+            .to_string()
+    })?;
+    if is_valid_target(&target) {
+        Ok(target)
+    } else {
+        Err("COKAC_HERDR_AGENT contains an invalid Herdr agent name.".to_string())
+    }
+}
+
+fn herdr_path() -> Option<String> {
+    if let Ok(path) = std::env::var("COKAC_HERDR_PATH") {
+        if !path.is_empty() && Path::new(&path).is_file() {
+            return Some(path);
+        }
+    }
+    let output = Command::new("which").arg("herdr").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!path.is_empty() && Path::new(&path).is_file()).then_some(path)
+}
+
+pub fn is_herdr_available() -> bool {
+    herdr_path().is_some()
+}
+
+fn timeout_ms() -> u64 {
+    std::env::var("COKAC_HERDR_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value >= 1000)
+        .unwrap_or(DEFAULT_TIMEOUT_MS)
+}
+
+fn read_lines() -> u32 {
+    std::env::var("COKAC_HERDR_READ_LINES")
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_READ_LINES)
+}
+
+fn command(bin: &str) -> Command {
+    let mut command = Command::new(bin);
+    command.env("PATH", enhanced_path_for_bin(bin));
+    command
+}
+
+fn output_error(action: &str, output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if !stderr.is_empty() { stderr } else { stdout };
+    if detail.is_empty() {
+        format!(
+            "Herdr {action} failed with exit code {}.",
+            output
+                .status
+                .code()
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        )
+    } else {
+        format!("Herdr {action} failed: {detail}")
+    }
+}
+
+fn read_agent(bin: &str, target: &str) -> Result<String, String> {
+    let output = command(bin)
+        .args([
+            "agent",
+            "read",
+            target,
+            "--source",
+            "recent-unwrapped",
+            "--lines",
+            &read_lines().to_string(),
+            "--format",
+            "text",
+        ])
+        .output()
+        .map_err(|error| format!("Failed to run Herdr agent read: {error}"))?;
+    if !output.status.success() {
+        return Err(output_error("agent read", &output));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).replace('\r', ""))
+}
+
+fn snapshot_delta(before: &str, after: &str) -> String {
+    let before_lines: Vec<&str> = before.lines().collect();
+    let after_lines: Vec<&str> = after.lines().collect();
+    let max_overlap = before_lines.len().min(after_lines.len());
+    for overlap in (1..=max_overlap).rev() {
+        if before_lines[before_lines.len() - overlap..] == after_lines[..overlap] {
+            return after_lines[overlap..].join("\n").trim().to_string();
+        }
+    }
+    after.trim().to_string()
+}
+
+fn current_turn_output(before: &str, after: &str, prompt: &str) -> String {
+    let prompt = prompt.trim();
+    if !prompt.is_empty() && !prompt.contains('\n') {
+        let needle = format!("› {prompt}");
+        if let Some(index) = after.rfind(&needle) {
+            return after[index + needle.len()..].trim().to_string();
+        }
+    }
+    snapshot_delta(before, after)
+}
+
+fn is_tui_separator(line: &str) -> bool {
+    let line = line.trim();
+    line.chars().count() >= 20 && line.chars().all(|character| character == '─')
+}
+
+fn is_tui_elapsed_time(line: &str) -> bool {
+    let line = line.trim();
+    line.starts_with('─') && line.contains("Worked for ") && line.ends_with('─')
+}
+
+fn codex_final_response(turn_output: &str) -> Option<String> {
+    let lines: Vec<&str> = turn_output.lines().collect();
+    let input_index = lines
+        .iter()
+        .rposition(|line| line.trim_start().starts_with("› "))
+        .unwrap_or(lines.len());
+    let response_index = lines[..input_index]
+        .iter()
+        .rposition(|line| line.trim_start().starts_with("• "))?;
+    let first_line = lines[response_index]
+        .trim_start()
+        .strip_prefix("• ")?
+        .trim_end();
+    let response_end = lines[response_index + 1..input_index]
+        .iter()
+        .position(|line| is_tui_separator(line) || is_tui_elapsed_time(line))
+        .map(|offset| response_index + 1 + offset)
+        .unwrap_or(input_index);
+
+    let mut output = vec![first_line.to_string()];
+    output.extend(lines[response_index + 1..response_end].iter().map(|line| {
+        line.strip_prefix("  ")
+            .unwrap_or(line)
+            .trim_end()
+            .to_string()
+    }));
+    let output = output.join("\n").trim().to_string();
+    if output.is_empty() {
+        None
+    } else {
+        Some(output)
+    }
+}
+
+fn interrupt_agent(bin: &str, target: &str) {
+    let _ = command(bin)
+        .args(["agent", "send-keys", target, "ctrl+c"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+pub fn execute_command_streaming(
+    prompt: &str,
+    sender: Sender<StreamMessage>,
+    cancel_token: Option<std::sync::Arc<CancelToken>>,
+    model: Option<&str>,
+) -> Result<(), String> {
+    let bin = herdr_path()
+        .ok_or_else(|| "Herdr CLI not found. Set COKAC_HERDR_PATH or install herdr.".to_string())?;
+    let target = target_from_model(model)?;
+    let before = read_agent(&bin, &target)?;
+
+    let mut prompt_command = command(&bin);
+    prompt_command
+        .args([
+            "agent",
+            "prompt",
+            &target,
+            prompt,
+            "--wait",
+            "--until",
+            "idle",
+            "--until",
+            "done",
+            "--until",
+            "blocked",
+            "--timeout",
+            &timeout_ms().to_string(),
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    detach_into_own_pgroup(&mut prompt_command);
+    attach_cancel_cgroup(&mut prompt_command, cancel_token.as_ref());
+    let mut child = prompt_command
+        .spawn()
+        .map_err(|error| format!("Failed to run Herdr agent prompt: {error}"))?;
+
+    if let Some(token) = cancel_token.as_ref() {
+        let mut child_pid = token
+            .child_pid
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *child_pid = Some(child.id());
+        drop(child_pid);
+        if token.cancelled.load(Ordering::Relaxed) {
+            kill_child_tree(&mut child);
+        }
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|error| format!("Failed waiting for Herdr agent: {error}"))?;
+
+    if let Some(token) = cancel_token.as_ref() {
+        let mut child_pid = token
+            .child_pid
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *child_pid = None;
+        if token.cancelled.load(Ordering::Relaxed) {
+            drop(child_pid);
+            interrupt_agent(&bin, &target);
+            return Ok(());
+        }
+    }
+
+    if !output.status.success() {
+        return Err(output_error("agent prompt", &output));
+    }
+    let prompt_result: Value = serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("Herdr returned invalid prompt JSON: {error}"))?;
+    if prompt_result.get("error").is_some() {
+        return Err(format!("Herdr agent prompt failed: {prompt_result}"));
+    }
+
+    let after = read_agent(&bin, &target)?;
+    let turn_output = current_turn_output(&before, &after, prompt);
+    let response = codex_final_response(&turn_output).unwrap_or(turn_output);
+    if response.trim().is_empty() {
+        return Err("Herdr agent completed without readable terminal output.".to_string());
+    }
+
+    send_success_terminal(&sender, Some(response.clone()), response, None)
+        .map_err(|error| format!("Failed to publish Herdr response: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_models_and_targets() {
+        assert!(is_herdr_model(Some("herdr")));
+        assert!(is_herdr_model(Some("herdr:worker_1")));
+        assert!(!is_herdr_model(Some("codex")));
+        assert_eq!(strip_herdr_prefix("herdr:worker"), Some("worker"));
+        assert!(is_valid_target("worker-1"));
+        assert!(!is_valid_target("Worker"));
+        assert!(!is_valid_target("../worker"));
+    }
+
+    #[test]
+    fn extracts_codex_final_response() {
+        let snapshot = "\
+› Hello\n\
+\n\
+• I will check the status.\n\
+\n\
+• Ran git status\n\
+  └ clean\n\
+\n\
+────────────────────────────────\n\
+\n\
+• Hello! How can I help?\n\
+  - First item\n\
+  - Second item\n\
+\n\
+────────────────────────────────\n\
+\n\
+› Use /skills to list available skills";
+        assert_eq!(
+            codex_final_response(snapshot).as_deref(),
+            Some("Hello! How can I help?\n- First item\n- Second item")
+        );
+    }
+
+    #[test]
+    fn extracts_current_turn_without_separator() {
+        let before = "\
+• Previous answer\n\
+\n\
+› Use /skills to list available skills";
+        let after = format!(
+            "{before}\n\
+\n\
+› Reply normally.\n\
+\n\
+• Understood. I will reply normally.\n\
+\n\
+› Use /skills to list available skills"
+        );
+        let turn = current_turn_output(before, &after, "Reply normally.");
+        assert_eq!(
+            codex_final_response(&turn).as_deref(),
+            Some("Understood. I will reply normally.")
+        );
+    }
+
+    #[test]
+    fn excludes_codex_elapsed_time_chrome() {
+        let output = "\
+• Completed the task.\n\
+\n\
+─ Worked for 1m 02s ─────────────────────────\n\
+\n\
+› Use /skills to list available skills";
+        assert_eq!(
+            codex_final_response(output).as_deref(),
+            Some("Completed the task.")
+        );
+    }
+
+    #[test]
+    fn extracts_snapshot_suffix() {
+        assert_eq!(
+            snapshot_delta("old one\nold two", "old two\nnew one\nnew two"),
+            "new one\nnew two"
+        );
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -4,6 +4,7 @@ pub mod claude;
 pub mod codex;
 pub mod dedup;
 pub mod file_ops;
+pub mod herdr;
 pub mod memory;
 pub mod messenger_bridge;
 pub mod opencode;

--- a/src/services/telegram.rs
+++ b/src/services/telegram.rs
@@ -20,6 +20,7 @@ use crate::services::file_ops::{
     stable_file_identity, stable_path_identity, DirectoryAccess, DirectoryFileOptions,
     StablePathIdentity,
 };
+use crate::services::herdr;
 use crate::services::memory::{self, MemoryTurn};
 use crate::services::opencode;
 use crate::ui::ai_screen::{self, HistoryItem, HistoryType, SessionData};
@@ -18101,7 +18102,9 @@ enum SessionProvider {
 /// Detect provider from model prefix only (no availability fallback).
 /// Returns "claude" when model is None or has no recognized prefix.
 fn provider_from_model(model: Option<&str>) -> &'static str {
-    if codex::is_codex_model(model) {
+    if herdr::is_herdr_model(model) {
+        "herdr"
+    } else if codex::is_codex_model(model) {
         "codex"
     } else if agy::is_agy_model(model) {
         "agy"
@@ -18122,6 +18125,11 @@ fn detect_provider(model: Option<&str>) -> &'static str {
         "agy"
     } else if !claude::is_claude_available() && opencode::is_opencode_available() {
         "opencode"
+    } else if !claude::is_claude_available()
+        && herdr::is_herdr_available()
+        && herdr::target_from_model(None).is_ok()
+    {
+        "herdr"
     } else {
         "claude"
     }
@@ -23163,6 +23171,14 @@ fn resolve_model_name(name: &str) -> Result<String, &'static str> {
         } else {
             Err("opencode")
         }
+    } else if herdr::is_herdr_model(Some(clean)) {
+        if !herdr::is_herdr_available() {
+            return Err("herdr");
+        }
+        if herdr::target_from_model(Some(clean)).is_err() {
+            return Err("");
+        }
+        Ok(clean.to_string())
     } else {
         Err("") // invalid format
     }
@@ -23600,6 +23616,7 @@ async fn handle_model_command(
         let has_codex = codex::is_codex_available();
         let has_agy = agy::is_agy_available();
         let has_opencode = opencode::is_opencode_available();
+        let has_herdr = herdr::is_herdr_available();
 
         let mut msg = match &current {
             Some(m) => format!("Current model: <b>{}</b>\n", m),
@@ -23610,8 +23627,12 @@ async fn handle_model_command(
                     "codex"
                 } else if has_agy {
                     "agy"
-                } else {
+                } else if has_opencode {
                     "opencode"
+                } else if has_herdr {
+                    "herdr"
+                } else {
+                    "none"
                 };
                 format!("Current model: <b>default</b> ({})\n", default_provider)
             }
@@ -23660,6 +23681,16 @@ async fn handle_model_command(
             msg.push_str("<code>/model opencode</code> — default\n");
             for model_id in opencode::list_models() {
                 msg.push_str(&format!("<code>/model opencode:{}</code>\n", model_id));
+            }
+        }
+        if has_herdr {
+            msg.push_str("\n<b>Herdr:</b>\n");
+            msg.push_str("<code>/model herdr:&lt;agent-name&gt;</code>\n");
+            if let Ok(target) = herdr::target_from_model(None) {
+                msg.push_str(&format!(
+                    "<code>/model herdr</code> — configured agent: {}\n",
+                    html_escape(&target)
+                ));
             }
         }
 
@@ -23825,7 +23856,8 @@ async fn handle_model_command(
                  <code>/model claude</code> or <code>/model claude:&lt;model&gt;</code>\n\
                  <code>/model codex</code> or <code>/model codex:&lt;model&gt;</code>\n\
                  <code>/model agy</code> or <code>/model agy:&lt;model&gt;</code>\n\
-                 <code>/model opencode</code> or <code>/model opencode:&lt;model&gt;</code>"
+                 <code>/model opencode</code> or <code>/model opencode:&lt;model&gt;</code>\n\
+                 <code>/model herdr:&lt;agent-name&gt;</code>"
                 )
                 .parse_mode(ParseMode::Html)
                 .await
@@ -24876,7 +24908,19 @@ async fn handle_text_message(
             ));
             ai_trace(&format!("[EXEC] provider={}, model={:?}, prompt_len={}, system_prompt_len={}, history_len={}, session={:?}, path={}",
                 provider, model_clone, context_prompt.len(), system_prompt_owned.len(), history_clone.len(), session_id_clone, current_path_clone));
-            let result = if provider == "opencode" {
+            let result = if provider == "herdr" {
+                msg_debug(&format!(
+                    "[handle_text_message] → herdr::execute, target={:?}, prompt_len={}",
+                    model_clone.as_deref().and_then(herdr::strip_herdr_prefix),
+                    context_prompt.len()
+                ));
+                herdr::execute_command_streaming(
+                    &context_prompt,
+                    tx.clone(),
+                    Some(cancel_token_clone),
+                    model_clone.as_deref(),
+                )
+            } else if provider == "opencode" {
                 let opencode_model = model_clone
                     .as_deref()
                     .and_then(opencode::strip_opencode_prefix);
@@ -30832,7 +30876,21 @@ async fn execute_schedule(
             provider, model_clone_for_exec, resume_session_id, claude_fork_session
         ));
         let resume_ref = resume_session_id.as_deref();
-        let result = if provider == "opencode" {
+        let result = if provider == "herdr" {
+            sched_debug(&format!(
+                "[execute_schedule] → herdr::execute, target={:?}, prompt_len={}",
+                model_clone_for_exec
+                    .as_deref()
+                    .and_then(herdr::strip_herdr_prefix),
+                prompt.len()
+            ));
+            herdr::execute_command_streaming(
+                &prompt,
+                tx.clone(),
+                Some(cancel_token_clone),
+                model_clone_for_exec.as_deref(),
+            )
+        } else if provider == "opencode" {
             let opencode_model = model_clone_for_exec
                 .as_deref()
                 .and_then(opencode::strip_opencode_prefix);
@@ -32349,7 +32407,19 @@ async fn process_bot_message(
             "[process_bot_message:spawn_blocking] provider={}, model={:?}",
             provider, model_clone
         ));
-        let result = if provider == "opencode" {
+        let result = if provider == "herdr" {
+            msg_debug(&format!(
+                "[process_bot_message] → herdr::execute, target={:?}, prompt_len={}",
+                model_clone.as_deref().and_then(herdr::strip_herdr_prefix),
+                prompt_for_ai.len()
+            ));
+            herdr::execute_command_streaming(
+                &prompt_for_ai,
+                tx.clone(),
+                Some(cancel_token_clone),
+                model_clone.as_deref(),
+            )
+        } else if provider == "opencode" {
             let opencode_model = model_clone
                 .as_deref()
                 .and_then(opencode::strip_opencode_prefix);
@@ -33990,7 +34060,14 @@ async fn execute_companion_ping(
     };
     let _ = spawn_tracked_blocking_task(request_tasks, move || {
         let provider = detect_provider(model_clone.as_deref());
-        let result = if provider == "opencode" {
+        let result = if provider == "herdr" {
+            herdr::execute_command_streaming(
+                &prompt,
+                tx.clone(),
+                Some(cancel_token_clone),
+                model_clone.as_deref(),
+            )
+        } else if provider == "opencode" {
             let opencode_model = model_clone
                 .as_deref()
                 .and_then(opencode::strip_opencode_prefix);


### PR DESCRIPTION
## 변경 사항

- 실행 중인 Herdr 에이전트에 Telegram 요청을 전달하는 `herdr` provider를 추가합니다.
- `/model herdr:<agent-name>` 형식으로 에이전트를 선택할 수 있습니다.
- Herdr 명령 경로, 기본 에이전트, 타임아웃 및 읽기 범위를 환경변수로 설정할 수 있습니다.
- 터미널 출력에서 현재 응답을 추출하고 시각적 줄바꿈을 정리하되 Markdown 목록과 코드 블록은 보존합니다.
- 설정 방법과 사용법 문서를 추가합니다.

## 배경

Cokacdir에서 이미 실행 중인 Herdr 에이전트와 대화를 이어가려면 별도의 provider가 필요합니다. 이 변경은 Herdr의 agent prompt/status/read 명령을 사용해 기존 Telegram 처리 흐름에 Herdr를 연결합니다.

## 사용자 영향

- Herdr가 설치된 환경에서 기존 에이전트 세션을 Cokacdir의 모델로 선택할 수 있습니다.
- Herdr가 없거나 대상 이름이 잘못된 경우 기존 provider와 동일한 방식으로 명확한 오류를 반환합니다.
- 기존 Claude, Codex, Agy 및 OpenCode 동작은 유지됩니다.

## 검증

- `cargo test herdr`
  - 7 passed
  - 0 failed
- upstream `main` 기준 `git diff --check` 통과

## 후속 작업

Herdr pane의 현재 화면을 조회하는 `/screen` 명령과 Telegram 버튼은 이 PR에 포함하지 않았습니다. 이 provider PR이 병합된 뒤 별도 후속 PR로 제출할 예정입니다.
